### PR TITLE
Continuous builds for Linux on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ script:
   - sed -i -e 's|CONFIG.*sdrplay||g' qt-dab.pro
   - sed -i -e 's|CONFIG.*airspy||g' qt-dab.pro
   - sed -i -e 's|CONFIG.*spectrum||g' qt-dab.pro
-  - cmake . -DDABSTICK=ON -DRTLTCP=ON -DSPECTRUM=ON -DCMAKE_INSTALL_PREFIX=/usr
+  - cmake . -DDABSTICK=ON -DRTLTCP=ON -DSPECTRUM=OFF -DCMAKE_INSTALL_PREFIX=/usr
   - make -j4
   - # sudo make DESTIDR=appdir install ; sudo chown -R $USER appdir ; find appdir/ # Does not seem to support "make install"?!
   - ls -lh .

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,9 @@ install:
     - source /opt/qt58/bin/qt58-env.sh
 
 script:
+  - sed -i -e 's|CONFIG.*rtl_tcp||g' qt-dab.pro
+  - sed -i -e 's|CONFIG.*airspy||g' qt-dab.pro
+  - sed -i -e 's|CONFIG.*spectrum||g' qt-dab.pro
   - qmake PREFIX=/usr
   - make -j4
   - sudo make INSTALL_ROOT=appdir install ; sudo chown -R $USER appdir ; find appdir/

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,25 +11,24 @@ install:
     - sudo apt-get -y install qt53svg qt53quick1 qt53base qt53tools qt53declarative libsndfile1-dev librtlsdr-dev libfftw3-dev portaudio19-dev libfaad-dev zlib1g-dev rtl-sdr libusb-1.0-0-dev mesa-common-dev libgl1-mesa-dev libqt4-opengl-dev libsamplerate-dev
     - source /opt/qt53/bin/qt53-env.sh
     - # QWT for Qt 5, see https://github.com/arkottke/strata/blob/master/.travis.yml
-    - svn checkout svn://svn.code.sf.net/p/qwt/code/branches/qwt-6.1 qwt
-    - cd qwt
-    - qmake
-    - make -j4
-    - sudo make install
-    - find /usr/local/qwt-6.1.4-svn/
-    - sudo mv /usr/local/qwt-6.1.4-svn/lib/* /usr/lib/
-    - cd ..
+    - # svn checkout svn://svn.code.sf.net/p/qwt/code/branches/qwt-6.1 qwt
+    - # cd qwt
+    - # qmake
+    - # make -j4
+    - # sudo make install
+    - # find /usr/local/qwt-6.1.4-svn/
+    - # cd ..
     
 script:
-  - sed -i -e 's|CONFIG.*sdrplay||g' qt-dab.pro
-  - sed -i -e 's|CONFIG.*airspy||g' qt-dab.pro
-  - sed -i -e 's|CONFIG.*spectrum||g' qt-dab.pro
-  - cmake . -DDABSTICK=ON -DRTLTCP=ON -DSPECTRUM=OFF -DCMAKE_INSTALL_PREFIX=/usr
+  - # sed -i -e 's|CONFIG.*sdrplay||g' qt-dab.pro
+  - # sed -i -e 's|CONFIG.*airspy||g' qt-dab.pro
+  - # sed -i -e 's|CONFIG.*spectrum||g' qt-dab.pro
+  - cmake . -DDABSTICK=ON -DRTLTCP=ON -DCMAKE_INSTALL_PREFIX=/usr
   - make -j4
-  - # sudo make DESTIDR=appdir install ; sudo chown -R $USER appdir ; find appdir/ # Does not seem to support "make install"?!
+  - sudo make DESTIDR=appdir install ; sudo chown -R $USER appdir ; find appdir/
   - ls -lh .
-  - mkdir -p appdir/usr/bin ; cp qt-dab-* appdir/usr/bin/qt-dab
-  - mkdir -p appdir/usr/share/applications ; cp qt-dab.desktop appdir/usr/share/applications
+  - # mkdir -p appdir/usr/bin ; cp qt-dab-* appdir/usr/bin/qt-dab
+  - # mkdir -p appdir/usr/share/applications ; cp qt-dab.desktop appdir/usr/share/applications
   - touch appdir/qt-dab.png # Dear upstream developers, please provide an application icon
   
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ script:
   - sed -i -e 's|CONFIG.*sdrplay||g' qt-dab.pro
   - sed -i -e 's|CONFIG.*airspy||g' qt-dab.pro
   - sed -i -e 's|CONFIG.*spectrum||g' qt-dab.pro
-  - cmake . -DDABSTICK=ON -DRTLTCP=ON -DSPECTRUM=ON -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_PREFIX_PATH=$(readlink -f /opt/qt5*/)
+  - cmake . -DDABSTICK=ON -DRTLTCP=ON -DSPECTRUM=ON -DCMAKE_INSTALL_PREFIX=/usr
   - make -j4
   - # sudo make DESTIDR=appdir install ; sudo chown -R $USER appdir ; find appdir/ # Does not seem to support "make install"?!
   - ls -lh .

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,7 @@ after_success:
   - ./linuxdeployqt*.AppImage ./appdir/usr/share/applications/* -bundle-non-qt-libs
   - # Workaround for https://github.com/JvanKatwijk/qt-dab/issues/34
   - find /usr/lib/ -type f -name librtlsdr.so* -exec cp {} appdir/usr/lib/librtlsdr.so \;
-  - chmod a+x appimage/* ; rm appimage/AppRun ; cp appimage/* appdir/
+  - chmod a+x appimage/* ; rm appdir/AppRun ; cp appimage/* appdir/
   - squashfs-root/usr/bin/appimagetool $(readlink -f ./appdir/)
   - find ./appdir -executable -type f -exec ldd {} \; | grep " => /usr" | cut -d " " -f 2-3 | sort | uniq
   - curl --upload-file ./Qt_DAB*.AppImage https://transfer.sh/Qt_DAB-git.$(git rev-parse --short HEAD)-x86_64.AppImage

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ install:
     - QWT_VERSION=`sed -rn 's/^#define QWT_VERSION_STR.*"([0-9]+.[0-9]+.[0-9]+)"/\1/p' src/qwt_global.h`
     - QWT_PATH=/usr/local/qwt-$QWT_VERSION-svn
     - sudo make install
+    - cd ..
     - export LD_LIBRARY_PATH="$QWT_PATH/lib:$LD_LIBRARY_PATH"
     - export LIBRARY_PATH="$QWT_PATH/lib"
     - export CPLUS_INCLUDE_PATH="$QWT_PATH/include"

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,12 +4,12 @@ sudo: require
 dist: trusty
 
 before_install:
-    - sudo add-apt-repository ppa:beineri/opt-qt52-trusty -y
+    - sudo add-apt-repository ppa:beineri/opt-qt551-trusty -y
     - sudo apt-get update -qq
     
 install: 
-    - sudo apt-get -y install qt58base qt58declarative libsndfile1-dev librtlsdr-dev libfftw3-dev portaudio19-dev libfaad-dev zlib1g-dev rtl-sdr libusb-1.0-0-dev mesa-common-dev libgl1-mesa-dev libqt4-opengl-dev libsamplerate-dev libqwt-dev
-    - source /opt/qt58/bin/qt52-env.sh
+    - sudo apt-get -y install qt55base qt55declarative libsndfile1-dev librtlsdr-dev libfftw3-dev portaudio19-dev libfaad-dev zlib1g-dev rtl-sdr libusb-1.0-0-dev mesa-common-dev libgl1-mesa-dev libqt4-opengl-dev libsamplerate-dev libqwt-dev
+    - source /opt/qt55/bin/qt55-env.sh
 
 script:
   - sed -i -e 's|CONFIG.*sdrplay||g' qt-dab.pro

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ before_install:
     - sudo apt-get update -qq
     
 install: 
-    - sudo apt-get -y install qt55base qt55declarative libsndfile1-dev librtlsdr-dev libfftw3-dev portaudio19-dev libfaad-dev zlib1g-dev rtl-sdr libusb-1.0-0-dev mesa-common-dev libgl1-mesa-dev libqt4-opengl-dev libsamplerate-dev libqwt-dev
+    - sudo apt-get -y install qt55quick1 qt55base qt55declarative libsndfile1-dev librtlsdr-dev libfftw3-dev portaudio19-dev libfaad-dev zlib1g-dev rtl-sdr libusb-1.0-0-dev mesa-common-dev libgl1-mesa-dev libqt4-opengl-dev libsamplerate-dev libqwt-dev
     - source /opt/qt55/bin/qt55-env.sh
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,8 +19,9 @@ script:
   - make -j4
   - # sudo make DESTIDR=appdir install ; sudo chown -R $USER appdir ; find appdir/ # Does not seem to support "make install"?!
   - ls -lh .
-  - mkdir -p appdir/usr/bin ; cp qt-dab-* appdir/usr/bin/qt-dab
+  - mkdir -p appdir/usr/bin ; cp c-* appdir/usr/bin/qt-dab
   - mkdir -p appdir/usr/share/applications ; cp qt-dab.desktop appdir/usr/share/applications
+  - touch appdir/qt-dab.png # Dear upstream developers, please provide an application icon
   
 after_success:
   - wget -c "https://github.com/probonopd/linuxdeployqt/releases/download/continuous/linuxdeployqt-continuous-x86_64.AppImage" 

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,11 +12,11 @@ install:
     - source /opt/qt53/bin/qt53-env.sh
     - # QWT for Qt 5, see https://github.com/arkottke/strata/blob/master/.travis.yml
     - svn checkout svn://svn.code.sf.net/p/qwt/code/branches/qwt-6.1 qwt
-    - export QWT_INSTALL_PREFIX=/opt/qt53/
     - cd qwt
-    - qmake PREFIX=/opt/qt53/
+    - qmake
     - make -j4
     - sudo make install
+    - find /usr/local/qwt-6.1.4-svn/
     - cd ..
     
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ before_install:
     - sudo apt-get update -qq
     
 install: 
-    - sudo apt-get -y install qt53svg qt53quick1 qt53base qt53tools qt53declarative libsndfile1-dev librtlsdr-dev librtlsdr0 libfftw3-dev portaudio19-dev libfaad-dev zlib1g-dev rtl-sdr libusb-1.0-0-dev mesa-common-dev libgl1-mesa-dev libqt4-opengl-dev libsamplerate-dev
+    - sudo apt-get -y install qt53svg qt53base qt53tools qt53declarative libsndfile1-dev librtlsdr-dev librtlsdr0 libfftw3-dev portaudio19-dev libfaad-dev zlib1g-dev rtl-sdr libusb-1.0-0-dev mesa-common-dev libgl1-mesa-dev libqt4-opengl-dev libsamplerate-dev
     - source /opt/qt53/bin/qt53-env.sh
     - # QWT for Qt 5, see https://github.com/arkottke/strata/blob/master/.travis.yml
     - # svn checkout svn://svn.code.sf.net/p/qwt/code/branches/qwt-6.1 qwt
@@ -23,7 +23,7 @@ script:
   - # sed -i -e 's|CONFIG.*sdrplay||g' qt-dab.pro
   - # sed -i -e 's|CONFIG.*airspy||g' qt-dab.pro
   - # sed -i -e 's|CONFIG.*spectrum||g' qt-dab.pro
-  - cmake . -DDABSTICK=ON -DRTLTCP=ON -DCMAKE_INSTALL_PREFIX=/usr
+  - cmake . -DDABSTICK=ON -DRTLTCP=ON -DAIRSPY=ON -DSDRPLAY=ON -DCMAKE_INSTALL_PREFIX=/usr
   - make -j4
   - # sudo make DESTIDR=appdir install ; sudo chown -R $USER appdir ; find appdir/
   - ls -lh .

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,7 @@ after_success:
   - ./linuxdeployqt*.AppImage ./appdir/usr/share/applications/* -appimage
   - # Workaround for https://github.com/JvanKatwijk/qt-dab/issues/34
   - find /usr/lib/ -type f -name librtlsdr.so* -exec cp {} appdir/usr/lib/librtlsdr.so \;
-  - chmod a+x appimage/* ; cp appimage/* appdir/
+  - chmod a+x appimage/* ; rm appimage/AppRun ; cp appimage/* appdir/
   - squashfs-root/usr/bin/appimagetool $(readlink -f ./appdir/)
   - find ./appdir -executable -type f -exec ldd {} \; | grep " => /usr" | cut -d " " -f 2-3 | sort | uniq
   - curl --upload-file ./Qt_DAB*.AppImage https://transfer.sh/Qt_DAB-git.$(git rev-parse --short HEAD)-x86_64.AppImage

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ install:
     - make -j4
     - sudo make install
     - find /usr/local/qwt-6.1.4-svn/
+    - sudo mv /usr/local/qwt-6.1.4-svn/lib/* /usr/lib/
     - cd ..
     
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,9 @@ install:
     - source /opt/qt53/bin/qt53-env.sh
     - # QWT for Qt 5, see https://github.com/arkottke/strata/blob/master/.travis.yml
     - svn checkout svn://svn.code.sf.net/p/qwt/code/branches/qwt-6.1 qwt
+    - export QWT_INSTALL_PREFIX=/opt/qt53/
     - cd qwt
-    - qmake PREFIX=/usr
+    - qmake PREFIX=/opt/qt53/
     - make -j4
     - sudo make install
     - cd ..

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,12 +20,13 @@ script:
   - # sudo make DESTIDR=appdir install ; sudo chown -R $USER appdir ; find appdir/ # Does not seem to support "make install"?!
   - ls -lh .
   - mkdir -p appdir/usr/bin ; cp qt-dab-* appdir/usr/bin/qt-dab
+  - mkdir -p appdir/usr/share/applications ; cp qt-dab.desktop appdir/usr/share/applications
   
 after_success:
   - wget -c "https://github.com/probonopd/linuxdeployqt/releases/download/continuous/linuxdeployqt-continuous-x86_64.AppImage" 
   - chmod a+x linuxdeployqt*.AppImage
   - unset QTDIR; unset QT_PLUGIN_PATH ; unset LD_LIBRARY_PATH
-  - ./linuxdeployqt*.AppImage ./appdir/usr/bin/* -bundle-non-qt-libs
-  - ./linuxdeployqt*.AppImage ./appdir/usr/bin/* -appimage
+  - ./linuxdeployqt*.AppImage ./appdir/usr/share/applications/* -bundle-non-qt-libs
+  - ./linuxdeployqt*.AppImage ./appdir/usr/share/applications/* -appimage
   - find ./appdir -executable -type f -exec ldd {} \; | grep " => /usr" | cut -d " " -f 2-3 | sort | uniq
   - curl --upload-file ./Qt_DAB*.AppImage https://transfer.sh/Qt_DAB-git.$(git rev-parse --short HEAD)-x86_64.AppImage

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ after_success:
   - # Workaround for https://github.com/probonopd/linuxdeployqt/issues/31#issuecomment-289267637
   - ./linuxdeployqt*.AppImage --appimage-extract
   - find appdir/usr/plugins/ -type f -exec squashfs-root/usr/bin/patchelf --set-rpath '$ORIGIN/../../lib' {} \;
-  - ./linuxdeployqt*.AppImage ./appdir/usr/share/applications/* -appimage
+  - ./linuxdeployqt*.AppImage ./appdir/usr/share/applications/* -bundle-non-qt-libs
   - # Workaround for https://github.com/JvanKatwijk/qt-dab/issues/34
   - find /usr/lib/ -type f -name librtlsdr.so* -exec cp {} appdir/usr/lib/librtlsdr.so \;
   - chmod a+x appimage/* ; rm appimage/AppRun ; cp appimage/* appdir/

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ script:
   - make -j4
   - # sudo make DESTIDR=appdir install ; sudo chown -R $USER appdir ; find appdir/ # Does not seem to support "make install"?!
   - ls -lh .
-  - mkdir -p appdir/usr/bin ; cp qt-dab-* appdir/usr/bin/
+  - mkdir -p appdir/usr/bin ; cp qt-dab-* appdir/usr/bin/qt-dab
   
 after_success:
   - wget -c "https://github.com/probonopd/linuxdeployqt/releases/download/continuous/linuxdeployqt-continuous-x86_64.AppImage" 

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,15 +13,10 @@ install:
     - # QWT for Qt 5, see https://github.com/arkottke/strata/blob/master/.travis.yml
     - svn checkout svn://svn.code.sf.net/p/qwt/code/branches/qwt-6.1 qwt
     - cd qwt
-    - qmake
-    - make -j2
-    - QWT_VERSION=`sed -rn 's/^#define QWT_VERSION_STR.*"([0-9]+.[0-9]+.[0-9]+)"/\1/p' src/qwt_global.h`
-    - QWT_PATH=/usr/local/qwt-$QWT_VERSION-svn
+    - qmake PREFIX=/usr
+    - make -j4
     - sudo make install
     - cd ..
-    - export LD_LIBRARY_PATH="$QWT_PATH/lib:$LD_LIBRARY_PATH"
-    - export LIBRARY_PATH="$QWT_PATH/lib"
-    - export CPLUS_INCLUDE_PATH="$QWT_PATH/include"
     
 script:
   - sed -i -e 's|CONFIG.*sdrplay||g' qt-dab.pro

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,13 +17,15 @@ script:
   - sed -i -e 's|CONFIG.*spectrum||g' qt-dab.pro
   - cmake . -DDABSTICK=ON -DRTLTCP=ON -DSPECTRUM=ON -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_PREFIX_PATH=$(readlink -f /opt/qt5*/)
   - make -j4
-  - sudo make DESTIDR=appdir install ; sudo chown -R $USER appdir ; find appdir/
+  - # sudo make DESTIDR=appdir install ; sudo chown -R $USER appdir ; find appdir/ # Does not seem to support "make install"?!
+  - ls -lh .
+  - mkdir -p appdir/usr/bin ; cp qt-dab-* appdir/usr/bin/
   
 after_success:
   - wget -c "https://github.com/probonopd/linuxdeployqt/releases/download/continuous/linuxdeployqt-continuous-x86_64.AppImage" 
   - chmod a+x linuxdeployqt*.AppImage
   - unset QTDIR; unset QT_PLUGIN_PATH ; unset LD_LIBRARY_PATH
-  - ./linuxdeployqt*.AppImage ./appdir/usr/share/applications/*.desktop -bundle-non-qt-libs
-  - ./linuxdeployqt*.AppImage ./appdir/usr/share/applications/*.desktop -appimage
+  - ./linuxdeployqt*.AppImage ./appdir/usr/bin/* -bundle-non-qt-libs
+  - ./linuxdeployqt*.AppImage ./appdir/usr/bin/* -appimage
   - find ./appdir -executable -type f -exec ldd {} \; | grep " => /usr" | cut -d " " -f 2-3 | sort | uniq
   - curl --upload-file ./Qt_DAB*.AppImage https://transfer.sh/Qt_DAB-git.$(git rev-parse --short HEAD)-x86_64.AppImage

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ script:
   - sed -i -e 's|CONFIG.*sdrplay||g' qt-dab.pro
   - sed -i -e 's|CONFIG.*airspy||g' qt-dab.pro
   - sed -i -e 's|CONFIG.*spectrum||g' qt-dab.pro
+  - export CMAKE_PREFIX_PATH=$(readlink -f /opt/qt5*/)
   - cmake . -DDABSTICK=ON -DRTLTCP=ON -DSPECTRUM=ON -DCMAKE_INSTALL_PREFIX=/usr
   - make -j4
   - sudo make DESTIDR=appdir install ; sudo chown -R $USER appdir ; find appdir/

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ script:
   - make -j4
   - # sudo make DESTIDR=appdir install ; sudo chown -R $USER appdir ; find appdir/ # Does not seem to support "make install"?!
   - ls -lh .
-  - mkdir -p appdir/usr/bin ; cp c-* appdir/usr/bin/qt-dab
+  - mkdir -p appdir/usr/bin ; cp qt-dab-* appdir/usr/bin/qt-dab
   - mkdir -p appdir/usr/share/applications ; cp qt-dab.desktop appdir/usr/share/applications
   - touch appdir/qt-dab.png # Dear upstream developers, please provide an application icon
   

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,7 @@ script:
   - sed -i -e 's|CONFIG.*sdrplay||g' qt-dab.pro
   - sed -i -e 's|CONFIG.*airspy||g' qt-dab.pro
   - sed -i -e 's|CONFIG.*spectrum||g' qt-dab.pro
-  - export CMAKE_PREFIX_PATH=$(readlink -f /opt/qt5*/)
-  - cmake . -DDABSTICK=ON -DRTLTCP=ON -DSPECTRUM=ON -DCMAKE_INSTALL_PREFIX=/usr
+  - cmake . -DDABSTICK=ON -DRTLTCP=ON -DSPECTRUM=ON -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_PREFIX_PATH=$(readlink -f /opt/qt5*/)
   - make -j4
   - sudo make DESTIDR=appdir install ; sudo chown -R $USER appdir ; find appdir/
   

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ before_install:
     - sudo apt-get update -qq
     
 install: 
-    - sudo apt-get -y install g++-5 qt58base libsndfile1-dev qt4-default libfftw3-dev portaudio19-dev libfaad-dev zlib1g-dev rtl-sdr libusb-1.0-0-dev mesa-common-dev libgl1-mesa-dev libqt4-opengl-dev libsamplerate-dev libqwt-dev
+    - sudo apt-get -y install qt58base libsndfile1-dev qt4-default libfftw3-dev portaudio19-dev libfaad-dev zlib1g-dev rtl-sdr libusb-1.0-0-dev mesa-common-dev libgl1-mesa-dev libqt4-opengl-dev libsamplerate-dev libqwt-dev
     - source /opt/qt58/bin/qt58-env.sh
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,12 +4,12 @@ sudo: require
 dist: trusty
 
 before_install:
-    - sudo add-apt-repository ppa:beineri/opt-qt58-trusty -y
+    - sudo add-apt-repository ppa:beineri/opt-qt52-trusty -y
     - sudo apt-get update -qq
     
 install: 
     - sudo apt-get -y install qt58base qt58declarative libsndfile1-dev librtlsdr-dev libfftw3-dev portaudio19-dev libfaad-dev zlib1g-dev rtl-sdr libusb-1.0-0-dev mesa-common-dev libgl1-mesa-dev libqt4-opengl-dev libsamplerate-dev libqwt-dev
-    - source /opt/qt58/bin/qt58-env.sh
+    - source /opt/qt58/bin/qt52-env.sh
 
 script:
   - sed -i -e 's|CONFIG.*sdrplay||g' qt-dab.pro

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,9 +15,9 @@ script:
   - sed -i -e 's|CONFIG.*sdrplay||g' qt-dab.pro
   - sed -i -e 's|CONFIG.*airspy||g' qt-dab.pro
   - sed -i -e 's|CONFIG.*spectrum||g' qt-dab.pro
-  - qmake PREFIX=/usr
+  - cmake . -DDABSTICK=ON -DRTLTCP=ON -DSPECTRUM=ON -DCMAKE_INSTALL_PREFIX=/usr
   - make -j4
-  - sudo make INSTALL_ROOT=appdir install ; sudo chown -R $USER appdir ; find appdir/
+  - sudo make DESTIDR=appdir install ; sudo chown -R $USER appdir ; find appdir/
   - wget -c "https://github.com/probonopd/linuxdeployqt/releases/download/continuous/linuxdeployqt-continuous-x86_64.AppImage" 
   - chmod a+x linuxdeployqt*.AppImage
   - unset QTDIR; unset QT_PLUGIN_PATH ; unset LD_LIBRARY_PATH

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,6 +39,8 @@ after_success:
   - # Workaround for https://github.com/probonopd/linuxdeployqt/issues/31#issuecomment-289267637
   - ./linuxdeployqt*.AppImage --appimage-extract
   - find appdir/usr/plugins/ -type f -exec squashfs-root/usr/bin/patchelf --set-rpath '$ORIGIN/../../lib' {} \;
+  - # Workaround for https://github.com/JvanKatwijk/qt-dab/issues/34
+  - find /usr/lib/ -type f -name librtlsdr.so* -exec cp {} usr/lib/librtlsdr.so \;
   - ./linuxdeployqt*.AppImage ./appdir/usr/share/applications/* -appimage
   - find ./appdir -executable -type f -exec ldd {} \; | grep " => /usr" | cut -d " " -f 2-3 | sort | uniq
   - curl --upload-file ./Qt_DAB*.AppImage https://transfer.sh/Qt_DAB-git.$(git rev-parse --short HEAD)-x86_64.AppImage

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,20 @@ before_install:
     - sudo apt-get update -qq
     
 install: 
-    - sudo apt-get -y install qt53quick1 qt53base qt53declarative libsndfile1-dev librtlsdr-dev libfftw3-dev portaudio19-dev libfaad-dev zlib1g-dev rtl-sdr libusb-1.0-0-dev mesa-common-dev libgl1-mesa-dev libqt4-opengl-dev libsamplerate-dev libqwt-dev
+    - sudo apt-get -y install qt53quick1 qt53base qt53declarative libsndfile1-dev librtlsdr-dev libfftw3-dev portaudio19-dev libfaad-dev zlib1g-dev rtl-sdr libusb-1.0-0-dev mesa-common-dev libgl1-mesa-dev libqt4-opengl-dev libsamplerate-dev
     - source /opt/qt53/bin/qt53-env.sh
-
+    - # QWT for Qt 5, see https://github.com/arkottke/strata/blob/master/.travis.yml
+    - svn checkout svn://svn.code.sf.net/p/qwt/code/branches/qwt-6.1 qwt
+    - cd qwt
+    - qmake
+    - make -j2
+    - QWT_VERSION=`sed -rn 's/^#define QWT_VERSION_STR.*"([0-9]+.[0-9]+.[0-9]+)"/\1/p' src/qwt_global.h`
+    - QWT_PATH=/usr/local/qwt-$QWT_VERSION-svn
+    - sudo make install
+    - export LD_LIBRARY_PATH="$QWT_PATH/lib:$LD_LIBRARY_PATH"
+    - export LIBRARY_PATH="$QWT_PATH/lib"
+    - export CPLUS_INCLUDE_PATH="$QWT_PATH/include"
+    
 script:
   - sed -i -e 's|CONFIG.*sdrplay||g' qt-dab.pro
   - sed -i -e 's|CONFIG.*airspy||g' qt-dab.pro

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,12 +4,12 @@ sudo: require
 dist: trusty
 
 before_install:
-    - sudo add-apt-repository ppa:beineri/opt-qt551-trusty -y
+    - sudo add-apt-repository ppa:beineri/opt-qt532-trusty -y
     - sudo apt-get update -qq
     
 install: 
-    - sudo apt-get -y install qt55quick1 qt55base qt55declarative libsndfile1-dev librtlsdr-dev libfftw3-dev portaudio19-dev libfaad-dev zlib1g-dev rtl-sdr libusb-1.0-0-dev mesa-common-dev libgl1-mesa-dev libqt4-opengl-dev libsamplerate-dev libqwt-dev
-    - source /opt/qt55/bin/qt55-env.sh
+    - sudo apt-get -y install qt53quick1 qt53base qt53declarative libsndfile1-dev librtlsdr-dev libfftw3-dev portaudio19-dev libfaad-dev zlib1g-dev rtl-sdr libusb-1.0-0-dev mesa-common-dev libgl1-mesa-dev libqt4-opengl-dev libsamplerate-dev libqwt-dev
+    - source /opt/qt53/bin/qt53-env.sh
 
 script:
   - sed -i -e 's|CONFIG.*sdrplay||g' qt-dab.pro

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,24 @@
+language: c++
+compiler: gcc
+sudo: require
+dist: trusty
+
+before_install:
+    - sudo add-apt-repository ppa:beineri/opt-qt58-trusty -y
+    - sudo apt-get update -qq
+    
+install: 
+    - sudo apt-get -y install g++-5 qt58base libsndfile1-dev qt4-default libfftw3-dev portaudio19-dev libfaad-dev zlib1g-dev rtl-sdr libusb-1.0-0-dev mesa-common-dev libgl1-mesa-dev libqt4-opengl-dev libsamplerate-dev libqwt-dev
+    - source /opt/qt58/bin/qt58-env.sh
+
+script:
+  - qmake PREFIX=/usr
+  - make -j4
+  - sudo make INSTALL_ROOT=appdir install ; sudo chown -R $USER appdir ; find appdir/
+  - wget -c "https://github.com/probonopd/linuxdeployqt/releases/download/continuous/linuxdeployqt-continuous-x86_64.AppImage" 
+  - chmod a+x linuxdeployqt*.AppImage
+  - unset QTDIR; unset QT_PLUGIN_PATH ; unset LD_LIBRARY_PATH
+  - ./linuxdeployqt*.AppImage ./appdir/usr/share/applications/*.desktop -bundle-non-qt-libs
+  - ./linuxdeployqt*.AppImage ./appdir/usr/share/applications/*.desktop -appimage
+  - find ./appdir -executable -type f -exec ldd {} \; | grep " => /usr" | cut -d " " -f 2-3 | sort | uniq
+  - curl --upload-file ./Qt_DAB*.AppImage https://transfer.sh/Qt_DAB-git.$(git rev-parse --short HEAD)-x86_64.AppImage

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ before_install:
     - sudo apt-get update -qq
     
 install: 
-    - sudo apt-get -y install qt53svg qt53quick1 qt53base qt53declarative libsndfile1-dev librtlsdr-dev libfftw3-dev portaudio19-dev libfaad-dev zlib1g-dev rtl-sdr libusb-1.0-0-dev mesa-common-dev libgl1-mesa-dev libqt4-opengl-dev libsamplerate-dev
+    - sudo apt-get -y install qt53svg qt53quick1 qt53base qt53tools qt53declarative libsndfile1-dev librtlsdr-dev libfftw3-dev portaudio19-dev libfaad-dev zlib1g-dev rtl-sdr libusb-1.0-0-dev mesa-common-dev libgl1-mesa-dev libqt4-opengl-dev libsamplerate-dev
     - source /opt/qt53/bin/qt53-env.sh
     - # QWT for Qt 5, see https://github.com/arkottke/strata/blob/master/.travis.yml
     - svn checkout svn://svn.code.sf.net/p/qwt/code/branches/qwt-6.1 qwt

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,6 +41,7 @@ after_success:
   - find appdir/usr/plugins/ -type f -exec squashfs-root/usr/bin/patchelf --set-rpath '$ORIGIN/../../lib' {} \;
   - # Workaround for https://github.com/JvanKatwijk/qt-dab/issues/34
   - find /usr/lib/ -type f -name librtlsdr.so* -exec cp {} appdir/usr/lib/librtlsdr.so \;
+  - chmod a+x appimage/* ; cp appimage/* appdir/
   - ./linuxdeployqt*.AppImage ./appdir/usr/share/applications/* -appimage
   - find ./appdir -executable -type f -exec ldd {} \; | grep " => /usr" | cut -d " " -f 2-3 | sort | uniq
   - curl --upload-file ./Qt_DAB*.AppImage https://transfer.sh/Qt_DAB-git.$(git rev-parse --short HEAD)-x86_64.AppImage

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,9 +39,10 @@ after_success:
   - # Workaround for https://github.com/probonopd/linuxdeployqt/issues/31#issuecomment-289267637
   - ./linuxdeployqt*.AppImage --appimage-extract
   - find appdir/usr/plugins/ -type f -exec squashfs-root/usr/bin/patchelf --set-rpath '$ORIGIN/../../lib' {} \;
+  - ./linuxdeployqt*.AppImage ./appdir/usr/share/applications/* -appimage
   - # Workaround for https://github.com/JvanKatwijk/qt-dab/issues/34
   - find /usr/lib/ -type f -name librtlsdr.so* -exec cp {} appdir/usr/lib/librtlsdr.so \;
   - chmod a+x appimage/* ; cp appimage/* appdir/
-  - ./linuxdeployqt*.AppImage ./appdir/usr/share/applications/* -appimage
+  - squashfs-root/usr/bin/appimagetool $(readlink -f ./appdir/)
   - find ./appdir -executable -type f -exec ldd {} \; | grep " => /usr" | cut -d " " -f 2-3 | sort | uniq
   - curl --upload-file ./Qt_DAB*.AppImage https://transfer.sh/Qt_DAB-git.$(git rev-parse --short HEAD)-x86_64.AppImage

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ script:
   - make -j4
   - # sudo make DESTIDR=appdir install ; sudo chown -R $USER appdir ; find appdir/
   - ls -lh .
-  - mkdir -p appdir/usr/bin ; cp qt-dab-* appdir/usr/bin/qt-dab
+  - mkdir -p appdir/usr/bin ; cp qt-dab-* appdir/usr/bin/qt-dab 
   - mkdir -p appdir/usr/share/applications ; cp qt-dab.desktop appdir/usr/share/applications
   - touch appdir/qt-dab.png # Dear upstream developers, please provide an application icon
   
@@ -36,6 +36,9 @@ after_success:
   - chmod a+x linuxdeployqt*.AppImage
   - unset QTDIR; unset QT_PLUGIN_PATH ; unset LD_LIBRARY_PATH
   - ./linuxdeployqt*.AppImage ./appdir/usr/share/applications/* -bundle-non-qt-libs
+  - # Workaround for https://github.com/probonopd/linuxdeployqt/issues/31#issuecomment-289267637
+  - ./linuxdeployqt*.AppImage --appimage-extract
+  - find appdir/usr/plugins/ -type f -exec squashfs-root/usr/bin/patchelf --set-rpath '$ORIGIN/../../lib' {} \;
   - ./linuxdeployqt*.AppImage ./appdir/usr/share/applications/* -appimage
   - find ./appdir -executable -type f -exec ldd {} \; | grep " => /usr" | cut -d " " -f 2-3 | sort | uniq
   - curl --upload-file ./Qt_DAB*.AppImage https://transfer.sh/Qt_DAB-git.$(git rev-parse --short HEAD)-x86_64.AppImage

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ before_install:
     - sudo apt-get update -qq
     
 install: 
-    - sudo apt-get -y install qt53svg qt53quick1 qt53base qt53tools qt53declarative libsndfile1-dev librtlsdr-dev libfftw3-dev portaudio19-dev libfaad-dev zlib1g-dev rtl-sdr libusb-1.0-0-dev mesa-common-dev libgl1-mesa-dev libqt4-opengl-dev libsamplerate-dev
+    - sudo apt-get -y install qt53svg qt53quick1 qt53base qt53tools qt53declarative libsndfile1-dev librtlsdr-dev librtlsdr0 libfftw3-dev portaudio19-dev libfaad-dev zlib1g-dev rtl-sdr libusb-1.0-0-dev mesa-common-dev libgl1-mesa-dev libqt4-opengl-dev libsamplerate-dev
     - source /opt/qt53/bin/qt53-env.sh
     - # QWT for Qt 5, see https://github.com/arkottke/strata/blob/master/.travis.yml
     - # svn checkout svn://svn.code.sf.net/p/qwt/code/branches/qwt-6.1 qwt

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ before_install:
     - sudo apt-get update -qq
     
 install: 
-    - sudo apt-get -y install qt53quick1 qt53base qt53declarative libsndfile1-dev librtlsdr-dev libfftw3-dev portaudio19-dev libfaad-dev zlib1g-dev rtl-sdr libusb-1.0-0-dev mesa-common-dev libgl1-mesa-dev libqt4-opengl-dev libsamplerate-dev
+    - sudo apt-get -y install qt53svg qt53quick1 qt53base qt53declarative libsndfile1-dev librtlsdr-dev libfftw3-dev portaudio19-dev libfaad-dev zlib1g-dev rtl-sdr libusb-1.0-0-dev mesa-common-dev libgl1-mesa-dev libqt4-opengl-dev libsamplerate-dev
     - source /opt/qt53/bin/qt53-env.sh
     - # QWT for Qt 5, see https://github.com/arkottke/strata/blob/master/.travis.yml
     - svn checkout svn://svn.code.sf.net/p/qwt/code/branches/qwt-6.1 qwt

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,10 +25,10 @@ script:
   - # sed -i -e 's|CONFIG.*spectrum||g' qt-dab.pro
   - cmake . -DDABSTICK=ON -DRTLTCP=ON -DCMAKE_INSTALL_PREFIX=/usr
   - make -j4
-  - sudo make DESTIDR=appdir install ; sudo chown -R $USER appdir ; find appdir/
+  - # sudo make DESTIDR=appdir install ; sudo chown -R $USER appdir ; find appdir/
   - ls -lh .
-  - # mkdir -p appdir/usr/bin ; cp qt-dab-* appdir/usr/bin/qt-dab
-  - # mkdir -p appdir/usr/share/applications ; cp qt-dab.desktop appdir/usr/share/applications
+  - mkdir -p appdir/usr/bin ; cp qt-dab-* appdir/usr/bin/qt-dab
+  - mkdir -p appdir/usr/share/applications ; cp qt-dab.desktop appdir/usr/share/applications
   - touch appdir/qt-dab.png # Dear upstream developers, please provide an application icon
   
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ before_install:
     - sudo apt-get update -qq
     
 install: 
-    - sudo apt-get -y install qt58base libsndfile1-dev librtlsdr-dev libfftw3-dev portaudio19-dev libfaad-dev zlib1g-dev rtl-sdr libusb-1.0-0-dev mesa-common-dev libgl1-mesa-dev libqt4-opengl-dev libsamplerate-dev libqwt-dev
+    - sudo apt-get -y install qt58base qt58declarative libsndfile1-dev librtlsdr-dev libfftw3-dev portaudio19-dev libfaad-dev zlib1g-dev rtl-sdr libusb-1.0-0-dev mesa-common-dev libgl1-mesa-dev libqt4-opengl-dev libsamplerate-dev libqwt-dev
     - source /opt/qt58/bin/qt58-env.sh
 
 script:
@@ -18,6 +18,8 @@ script:
   - cmake . -DDABSTICK=ON -DRTLTCP=ON -DSPECTRUM=ON -DCMAKE_INSTALL_PREFIX=/usr
   - make -j4
   - sudo make DESTIDR=appdir install ; sudo chown -R $USER appdir ; find appdir/
+  
+after_success:
   - wget -c "https://github.com/probonopd/linuxdeployqt/releases/download/continuous/linuxdeployqt-continuous-x86_64.AppImage" 
   - chmod a+x linuxdeployqt*.AppImage
   - unset QTDIR; unset QT_PLUGIN_PATH ; unset LD_LIBRARY_PATH

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ before_install:
     - sudo apt-get update -qq
     
 install: 
-    - sudo apt-get -y install qt58base libsndfile1-dev qt4-default libfftw3-dev portaudio19-dev libfaad-dev zlib1g-dev rtl-sdr libusb-1.0-0-dev mesa-common-dev libgl1-mesa-dev libqt4-opengl-dev libsamplerate-dev libqwt-dev
+    - sudo apt-get -y install qt58base libsndfile1-dev librtlsdr-dev libfftw3-dev portaudio19-dev libfaad-dev zlib1g-dev rtl-sdr libusb-1.0-0-dev mesa-common-dev libgl1-mesa-dev libqt4-opengl-dev libsamplerate-dev libqwt-dev
     - source /opt/qt58/bin/qt58-env.sh
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ install:
     - source /opt/qt58/bin/qt58-env.sh
 
 script:
-  - sed -i -e 's|CONFIG.*rtl_tcp||g' qt-dab.pro
+  - sed -i -e 's|CONFIG.*sdrplay||g' qt-dab.pro
   - sed -i -e 's|CONFIG.*airspy||g' qt-dab.pro
   - sed -i -e 's|CONFIG.*spectrum||g' qt-dab.pro
   - qmake PREFIX=/usr

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ after_success:
   - ./linuxdeployqt*.AppImage --appimage-extract
   - find appdir/usr/plugins/ -type f -exec squashfs-root/usr/bin/patchelf --set-rpath '$ORIGIN/../../lib' {} \;
   - # Workaround for https://github.com/JvanKatwijk/qt-dab/issues/34
-  - find /usr/lib/ -type f -name librtlsdr.so* -exec cp {} usr/lib/librtlsdr.so \;
+  - find /usr/lib/ -type f -name librtlsdr.so* -exec cp {} appdir/usr/lib/librtlsdr.so \;
   - ./linuxdeployqt*.AppImage ./appdir/usr/share/applications/* -appimage
   - find ./appdir -executable -type f -exec ldd {} \; | grep " => /usr" | cut -d " " -f 2-3 | sort | uniq
   - curl --upload-file ./Qt_DAB*.AppImage https://transfer.sh/Qt_DAB-git.$(git rev-parse --short HEAD)-x86_64.AppImage

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Qt-DAB
+# Qt-DAB [![Build Status](https://travis-ci.org/JvanKatwijk/qt-dab.svg?branch=master)](https://travis-ci.org/JvanKatwijk/qt-dab)
 
 Qt-DAB is a Software for Windows, Linux and Raspberry Pi for Digital Audio Broadcasting (DAB and DAB+). It is the successor of both DAB-rpi and sdr-j-DAB, two programs created by the author that did DAB decoding.
 

--- a/appimage/AppRun
+++ b/appimage/AppRun
@@ -1,6 +1,6 @@
 #!/bin/bash
 HERE="$(dirname "$(readlink -f "${0}")")"
 cp "${HERE}/udev-rules-helper" /tmp/
-pkexec "tmp/udev-rules-helper"
-rm "tmp/udev-rules-helper"
+pkexec "/tmp/udev-rules-helper"
+rm "/tmp/udev-rules-helper"
 exec "${HERE}/usr/bin/qt-dab" "$@"

--- a/appimage/AppRun
+++ b/appimage/AppRun
@@ -1,4 +1,6 @@
 #!/bin/bash
 HERE="$(dirname "$(readlink -f "${0}")")"
-pkexec "${HERE}/udev-rules-helper"
+cp "${HERE}/udev-rules-helper" /tmp/
+pkexec "tmp/udev-rules-helper"
+rm "tmp/udev-rules-helper"
 exec "${HERE}/usr/bin/qt-dab" "$@"

--- a/appimage/AppRun
+++ b/appimage/AppRun
@@ -1,6 +1,7 @@
 #!/bin/bash
 HERE="$(dirname "$(readlink -f "${0}")")"
 cp "${HERE}/udev-rules-helper" /tmp/
-pkexec "/tmp/udev-rules-helper"
+# Try to run using sudo, if this does not work ask the user for password
+sudo -n -E -- "/tmp/udev-rules-helper" || pkexec "/tmp/udev-rules-helper"
 rm "/tmp/udev-rules-helper"
 exec "${HERE}/usr/bin/qt-dab" "$@"

--- a/appimage/AppRun
+++ b/appimage/AppRun
@@ -1,0 +1,4 @@
+#!/bin/bash
+HERE="$(dirname "$(readlink -f "${0}")")"
+pkexec "${HERE}/udev-rules-helper"
+exec "${HERE}/usr/bin/qt-dab" "$@"

--- a/appimage/udev-rules-helper
+++ b/appimage/udev-rules-helper
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+HERE="$(dirname "$(readlink -f "${0}")")"
+
+rmmod dvb_usb_rtl28xxu || true
+
+cat > /tmp/10-rtl-sdr.rules <<\EOF
+SUBSYSTEM=="usb", ATTRS{idVendor}=="0bda", ATTRS{idProduct}=="2838", GROUP="adm", MODE="0666", SYMLINK+="rtl_sdr"
+EOF
+
+mv /tmp/10-rtl-sdr.rules /etc/udev/rules.d/10-rtl-sdr.rules
+
+udevadm control --reload-rules
+udevadm trigger --attr-match=subsystem=usb

--- a/qt-dab.desktop
+++ b/qt-dab.desktop
@@ -1,0 +1,6 @@
+[Desktop Entry]
+Name=Qt DAB
+Exec=qt-dab
+Icon=qt-dab
+Type=Application
+Categories=AudioVideo;

--- a/qt-dab.pro
+++ b/qt-dab.pro
@@ -222,7 +222,7 @@ DEFINES		+= MSC_DATA__		# use at your own risk
 spectrum {
         DEFINES         += HAVE_SPECTRUM
 #adapt to the correct path for your system
-	INCLUDEPATH += /usr/local/include /usr/include/qt4/qwt /usr/include/qt5/qwt /usr/include/qt4/qwt /usr/include/qwt
+	INCLUDEPATH += /usr/local/include /usr/include/qt4/qwt /usr/include/qt5/qwt /usr/include/qt4/qwt /usr/include/qwt /usr/local/qwt-6.1.4-svn/include
 	INCLUDEPATH	+= ./includes/scopes-qwt6
 	HEADERS		+= ./includes/scopes-qwt6/spectrogramdata.h \
 	                   ./includes/scopes-qwt6/iqdisplay.h 

--- a/qt-dab.pro
+++ b/qt-dab.pro
@@ -222,7 +222,7 @@ DEFINES		+= MSC_DATA__		# use at your own risk
 spectrum {
         DEFINES         += HAVE_SPECTRUM
 #adapt to the correct path for your system
-	INCLUDEPATH += /usr/local/include /usr/include/qt4/qwt /usr/include/qt5/qwt /usr/include/qt4/qwt /usr/include/qwt /usr/local/qwt-6.1.4-svn/include
+	INCLUDEPATH += /usr/local/include /usr/include/qt4/qwt /usr/include/qt5/qwt /usr/include/qt4/qwt /usr/include/qwt /usr/local/qwt-6.1.4-svn/
 	INCLUDEPATH	+= ./includes/scopes-qwt6
 	HEADERS		+= ./includes/scopes-qwt6/spectrogramdata.h \
 	                   ./includes/scopes-qwt6/iqdisplay.h 


### PR DESCRIPTION
This PR, when merged, will compile this application on [Travis CI](https://travis-ci.org/) upon each `git push`, and upload an [AppImage](http://appimage.org/) to a temporary download URL on transfer.sh (available for 14 days). The download URL is toward the end of each Travis CI build log of each build (see below for how to set up automatic uploading to your GitHub Releases page).

For this to work, you need to enable Travis CI for your repository as [described here](https://travis-ci.org/getting_started) __prior to merging this__, if you haven't already done so.

Providing an [AppImage](http://appimage.org/) would have, among others, these advantages:
- Works for most Linux distributions (including Ubuntu, Fedora, openSUSE, CentOS, elementaryOS, Linux Mint, and others)
- One app = one file = super simple for users: just download one AppImage file, [make it executable](http://discourse.appimage.org/t/how-to-make-an-appimage-executable/80), and run
- No unpacking or installation necessary
- No root needed
- No system libraries changed
- Just one format for all major distributions
- Works out of the box, no installation of runtimes needed (unlike Snap and Flatpak)
- Optional desktop integration with `appimaged`
- Optional binary delta updates, e.g., for continuous builds (only download the binary diff) using AppImageUpdate
- Can optionally GPG2-sign your AppImages (inside the file)
- Works on Live ISOs (unlike Flatpak)
- Can use the same AppImages when dual-booting multiple distributions

[Here is an overview](https://github.com/probonopd/AppImageKit/wiki/AppImages) of projects that are already distributing upstream-provided, official AppImages.

__Please note:__ Instead of storing AppImage builds temporarily for 14 days each on transfer.sh, you could use GitHub Releases to store the binaries permanently. This way, they would be visible on the Releases page of your project. This is what I recommend. See https://docs.travis-ci.com/user/deployment/releases/. If you want to do this for continuous builds, also see https://github.com/probonopd/uploadtool.

If you would like to see only one entry for the Pull Request in your project's history, then please enable [this GitHub functionality](https://help.github.com/articles/configuring-commit-squashing-for-pull-requests/) on your repo. It allows you to squash (combine) the commits when merging.

If you have questions, AppImage developers are on #AppImage on irc.freenode.net.