### PR TITLE
Declare qt network library

### DIFF
--- a/qt-dab.pro
+++ b/qt-dab.pro
@@ -7,6 +7,7 @@
 TEMPLATE	= app
 TARGET		= qt-dab-1.0-alpha
 
+QT		+= network
 QT		+= widgets 
 CONFIG		+= console
 QMAKE_CXXFLAGS	+= -std=c++11


### PR DESCRIPTION
Fixes compilation error:-

```
In file included from main.cpp:34:0:
radio.h:33:22: fatal error: QUdpSocket: No such file or directory
compilation terminated.
```