### PR TITLE
radio: Rename showPictures to showSlides as per documentation.

### DIFF
--- a/radio.cpp
+++ b/radio.cpp
@@ -161,7 +161,7 @@ QString h;
 	currentName		= QString ("");
 
 	saveSlides	= dabSettings -> value ("saveSlides", 1). toInt();
-	showSlides	= dabSettings -> value ("showPictures", 1). toInt();
+	showSlides	= dabSettings -> value ("showSlides", 1). toInt();
 	if (saveSlides != 0)
 	   set_picturePath();
 


### PR DESCRIPTION
Was setting `showSlides=0` and wondering why `qt-dab` was badgering me
with the "slides" I had explicitly opted out of receiving.