### PR TITLE
hackrf-handler: Fix name of libhackrf library

### DIFF
--- a/devices/hackrf-handler/hackrf-handler.cpp
+++ b/devices/hackrf-handler/hackrf-handler.cpp
@@ -48,7 +48,7 @@ int	res;
         const char *libraryString = "/opt/local/lib/libhackrf.dylib";
         Handle = dlopen(libraryString,RTLD_NOW);
 #else
-        const char *libraryString = "libhackrf.so";
+        const char *libraryString = "libhackrf.so.0";
         Handle          = dlopen (libraryString, RTLD_NOW);
 #endif
 


### PR DESCRIPTION
It's `libhackrf.so.0` on Ubuntu 18.04, not `libhackrf.so` (maybe this
should be configurable?).

I've also been able to successfully use `qt-dab` with the above patch on Gentoo Linux.