### PR TITLE
Fixed MHz value in main window

### DIFF
--- a/forms/dabradio.ui
+++ b/forms/dabradio.ui
@@ -308,7 +308,7 @@ it is definitely not the time on your clock.</string>
                <enum>QFrame::Sunken</enum>
               </property>
               <property name="digitCount">
-               <number>6</number>
+               <number>7</number>
               </property>
               <property name="segmentStyle">
                <enum>QLCDNumber::Flat</enum>


### PR DESCRIPTION
Now the frequency is displayed as xxx.xxx MHz instead of xxx.xx MHz (except for xxx.xx0 MHz channels)