### PR TITLE
Don't write MOT objects to disk if picturePath is not set.

### DIFF
--- a/dab-maxi/radio.cpp
+++ b/dab-maxi/radio.cpp
@@ -681,7 +681,7 @@ ensemblePrinter	my_Printer;
 
 //	showMOT is triggered by the MOT handler,
 void	RadioInterface::showMOT		(QByteArray data,
-                                         uint16_t contentType,
+                                         int contentType,
                                          QString pictureName) {
 const char *type;
 	if (!running. load())

--- a/dab-maxi/radio.cpp
+++ b/dab-maxi/radio.cpp
@@ -681,15 +681,28 @@ ensemblePrinter	my_Printer;
 
 //	showMOT is triggered by the MOT handler,
 void	RadioInterface::showMOT		(QByteArray data,
-	                                 int subtype, QString pictureName) {
+                                         MOTContentType contentType,
+                                         QString pictureName) {
 const char *type;
 	if (!running. load())
 	   return;
 
-	type = subtype == 0 ? "GIF" :
-	       subtype == 1 ? "JPG" :
-//	       subtype == 1 ? "JPEG" :
-	       subtype == 2 ? "BMP" : "PNG";
+        switch (contentType) {
+        case MOTCTImageGIF:
+                type = "GIF";
+                break;
+        case MOTCTImageJFIF:
+                type = "JPG";
+                break;
+        case MOTCTImageBMP:
+                type = "BMP";
+                break;
+        case MOTCTImagePNG:
+                type = "PNG";
+                break;
+        default:
+                return;
+        }
 
 	QPixmap p;
 	p. loadFromData (data, type);

--- a/dab-maxi/radio.cpp
+++ b/dab-maxi/radio.cpp
@@ -681,13 +681,13 @@ ensemblePrinter	my_Printer;
 
 //	showMOT is triggered by the MOT handler,
 void	RadioInterface::showMOT		(QByteArray data,
-                                         MOTContentType contentType,
+                                         uint16_t contentType,
                                          QString pictureName) {
 const char *type;
 	if (!running. load())
 	   return;
 
-        switch (contentType) {
+        switch (static_cast<MOTContentType>(contentType)) {
         case MOTCTImageGIF:
                 type = "GIF";
                 break;

--- a/dab-maxi/radio.h
+++ b/dab-maxi/radio.h
@@ -197,7 +197,7 @@ public slots:
 	void			setSynced		(bool);
 	void			showLabel		(QString);
 	void			showMOT			(QByteArray,
-                                                                  MOTContentType,
+                                                                  uint16_t,
 	                                                          QString);
 	void			sendDatagram		(int);
 	void			handle_tdcdata		(int, int);

--- a/dab-maxi/radio.h
+++ b/dab-maxi/radio.h
@@ -197,7 +197,7 @@ public slots:
 	void			setSynced		(bool);
 	void			showLabel		(QString);
 	void			showMOT			(QByteArray,
-                                                                  uint16_t,
+                                                                  int,
 	                                                          QString);
 	void			sendDatagram		(int);
 	void			handle_tdcdata		(int, int);

--- a/dab-maxi/radio.h
+++ b/dab-maxi/radio.h
@@ -25,6 +25,7 @@
 #define __RADIO__
 
 #include	"dab-constants.h"
+#include	"mot-content-types.h"
 #include	<QMainWindow>
 #include	<QStringList>
 #include	<QStandardItemModel>
@@ -195,7 +196,8 @@ public slots:
 	void			show_snr		(int);
 	void			setSynced		(bool);
 	void			showLabel		(QString);
-	void			showMOT			(QByteArray, int,
+	void			showMOT			(QByteArray,
+                                                                  MOTContentType,
 	                                                          QString);
 	void			sendDatagram		(int);
 	void			handle_tdcdata		(int, int);

--- a/dab-mini/radio.cpp
+++ b/dab-mini/radio.cpp
@@ -340,7 +340,7 @@ QString s;
 ///////////////////////////////////////////////////////////////////////////
 //	showMOT is triggered by the MOT handler,
 void	RadioInterface::showMOT		(QByteArray data,
-                                         MOTContentType contentType,
+                                         uint16_t contentType,
                                          QString pictureName) {
 	(void)data; (void)contentType; (void)pictureName;
 }

--- a/dab-mini/radio.cpp
+++ b/dab-mini/radio.cpp
@@ -340,8 +340,9 @@ QString s;
 ///////////////////////////////////////////////////////////////////////////
 //	showMOT is triggered by the MOT handler,
 void	RadioInterface::showMOT		(QByteArray data,
-	                                 int subtype, QString pictureName) {
-	(void)data; (void)subtype; (void)pictureName;
+                                         MOTContentType contentType,
+                                         QString pictureName) {
+	(void)data; (void)contentType; (void)pictureName;
 }
 //
 //	sendDatagram is triggered by the ip handler,

--- a/dab-mini/radio.cpp
+++ b/dab-mini/radio.cpp
@@ -340,7 +340,7 @@ QString s;
 ///////////////////////////////////////////////////////////////////////////
 //	showMOT is triggered by the MOT handler,
 void	RadioInterface::showMOT		(QByteArray data,
-                                         uint16_t contentType,
+                                         int contentType,
                                          QString pictureName) {
 	(void)data; (void)contentType; (void)pictureName;
 }

--- a/dab-mini/radio.h
+++ b/dab-mini/radio.h
@@ -141,7 +141,7 @@ public slots:
 	void			setSynced		(bool);
 	void			showLabel		(QString);
 	void			showMOT			(QByteArray,
-                                                                  MOTContentType,
+                                                                  uint16_t,
 	                                                          QString);
 	void			sendDatagram		(int);
 	void			handle_tdcdata		(int, int);

--- a/dab-mini/radio.h
+++ b/dab-mini/radio.h
@@ -25,6 +25,7 @@
 #define __SIMPLE_RADIO__
 
 #include	"dab-constants.h"
+#include	"mot-content-types.h"
 #include	<QMainWindow>
 #include	<QStringList>
 #include	<QStandardItemModel>
@@ -139,7 +140,8 @@ public slots:
 	void			show_snr		(int);
 	void			setSynced		(bool);
 	void			showLabel		(QString);
-	void			showMOT			(QByteArray, int,
+	void			showMOT			(QByteArray,
+                                                                  MOTContentType,
 	                                                          QString);
 	void			sendDatagram		(int);
 	void			handle_tdcdata		(int, int);

--- a/dab-mini/radio.h
+++ b/dab-mini/radio.h
@@ -141,7 +141,7 @@ public slots:
 	void			setSynced		(bool);
 	void			showLabel		(QString);
 	void			showMOT			(QByteArray,
-                                                                  uint16_t,
+                                                                  int,
 	                                                          QString);
 	void			sendDatagram		(int);
 	void			handle_tdcdata		(int, int);

--- a/dab-processor.cpp
+++ b/dab-processor.cpp
@@ -44,7 +44,7 @@
 	                                 int16_t	tii_delay,
 	                                 int16_t	tii_depth,
 	                                 int16_t	echo_depth,
-	                                 QString	picturesPath,
+	                                 const QString&	picturesPath,
 	                                 RingBuffer<float> *responseBuffer,
 		                         RingBuffer<std::complex<float>> *
 	                                                         spectrumBuffer,

--- a/dab-processor.h
+++ b/dab-processor.h
@@ -58,7 +58,7 @@ public:
 	                         int16_t,
 	                         int16_t,	// tii_depth
 	                         int16_t,	// echo_depth
-	                         QString,
+	                         const QString&,
 	                         RingBuffer<float> *,
 	                         RingBuffer<std::complex<float>>	*,
 	                         RingBuffer<std::complex<float>>	*,

--- a/includes/backend/audio/mp2processor.h
+++ b/includes/backend/audio/mp2processor.h
@@ -57,7 +57,7 @@ public:
 	                                 int16_t,
 	                                 RingBuffer<int16_t> *,
 	                                 RingBuffer<uint8_t> *,
-	                                 QString);
+	                                 const QString&);
 			~mp2Processor();
 	void		addtoFrame	(std::vector<uint8_t>);
 	void		setFile		(FILE *);

--- a/includes/backend/audio/mp4processor.h
+++ b/includes/backend/audio/mp4processor.h
@@ -53,7 +53,7 @@ public:
 	                                 int16_t,
 	                                 RingBuffer<int16_t> *,
 	                                 RingBuffer<uint8_t> *,
-	                                 QString);
+	                                 const QString&);
 			~mp4Processor();
 	void		addtoFrame	(std::vector<uint8_t>);
 private:

--- a/includes/backend/backend-driver.h
+++ b/includes/backend/backend-driver.h
@@ -36,7 +36,7 @@ public:
 	                 RingBuffer<int16_t> *,
 	                 RingBuffer<uint8_t> *,
 	                 RingBuffer<uint8_t> *,
-	                 QString);
+	                 const QString&);
     ~backendDriver();
 void	addtoFrame	(std::vector<uint8_t> outData);
 private:

--- a/includes/backend/backend.h
+++ b/includes/backend/backend.h
@@ -48,7 +48,7 @@ public:
 	                 RingBuffer<int16_t> *,
 	                 RingBuffer<uint8_t> *,
 	                 RingBuffer<uint8_t> *,
-	                 QString	picturesPath);
+	                 const QString&	picturesPath);
 		~Backend();
 	int32_t	process		(int16_t *, int16_t);
 	void	stopRunning();

--- a/includes/backend/data/data-processor.h
+++ b/includes/backend/data/data-processor.h
@@ -42,7 +42,7 @@ public:
 	dataProcessor	(RadioInterface *mr,
 	                 packetdata	*pd,
 	                 RingBuffer<uint8_t>	*dataBuffer,
-	                 QString	picturesPath);
+	                 const QString&	picturesPath);
 	~dataProcessor();
 void	addtoFrame	(std::vector<uint8_t>);
 private:

--- a/includes/backend/data/mot/mot-content-types.h
+++ b/includes/backend/data/mot/mot-content-types.h
@@ -1,0 +1,106 @@
+/*
+ *    Copyright (C) 2015 .. 2017
+ *    Jan van Katwijk (J.vanKatwijk@gmail.com)
+ *    Lazy Chair Computing
+ *
+ *    This file is part of the Qt-DAB program
+ *    Qt-DAB is free software; you can redistribute it and/or modify
+ *    it under the terms of the GNU General Public License as published by
+ *    the Free Software Foundation; either version 2 of the License, or
+ *    (at your option) any later version.
+ *
+ *    Qt-DAB is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *    GNU General Public License for more details.
+ *
+ *    You should have received a copy of the GNU General Public License
+ *    along with Qt-DAB; if not, write to the Free Software
+ *    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ */
+
+#ifndef	__MOT_CONTENT_TYPE__
+#define	__MOT_CONTENT_TYPE__
+
+// Content type codes, reference:
+// https://www.etsi.org/deliver/etsi_ts/101700_101799/101756/01.06.01_60/ts_101756v010601p.pdf page 20.
+
+enum MOTContentBaseType {
+	MOTBaseTypeGeneralData		= 0x00,
+	MOTBaseTypeText			= 0x01,
+	MOTBaseTypeImage		= 0x02,
+	MOTBaseTypeAudio		= 0x03,
+	MOTBaseTypeVideo		= 0x04,
+	MOTBaseTypeTransport		= 0x05,
+	MOTBaseTypeSystem		= 0x06,
+	MOTBaseTypeApplication		= 0x07,
+	MOTBaseTypeProprietary		= 0x3f
+};
+
+enum MOTContentType {
+	// Masks
+	MOTCTBaseTypeMask		= 0x3f00,
+	MOTCTSubTypeMask		= 0x00ff,
+
+	// General Data: 0x00xx
+	MOTCTGeneralDataObjectTransfer	= 0x0000,
+	MOTCTGeneralDataMIMEHTTP	= 0x0001,
+	// Text formats: 0x01xx
+	MOTCTTextASCII			= 0x0100,
+	MOTCTTextLatin1			= 0x0101,
+	MOTCTTextHTML			= 0x0102,
+	MOTCTTextPDF			= 0x0103,
+	// Image formats: 0x02xx
+	MOTCTImageGIF			= 0x0200,
+	MOTCTImageJFIF			= 0x0201,
+	MOTCTImageBMP			= 0x0202,
+	MOTCTImagePNG			= 0x0203,
+	// Audio formats: 0x03xx
+	MOTCTAudioMPEG1Layer1		= 0x0300,
+	MOTCTAudioMPEG1Layer2		= 0x0301,
+	MOTCTAudioMPEG1Layer3		= 0x0302,
+	MOTCTAudioMPEG2Layer1		= 0x0303,
+	MOTCTAudioMPEG2Layer2		= 0x0304,
+	MOTCTAudioMPEG2Layer3		= 0x0305,
+	MOTCTAudioPCM			= 0x0306,
+	MOTCTAudioAIFF			= 0x0307,
+	MOTCTAudioATRAC			= 0x0308,
+	MOTCTAudioUndefined		= 0x0309,
+	MOTCTAudioMPEG4			= 0x030a,
+	// Video formats: 0x04xx
+	MOTCTVideoMPEG1			= 0x0400,
+	MOTCTVideoMPEG2			= 0x0401,
+	MOTCTVideoMPEG4			= 0x0402,
+	MOTCTVideoH263			= 0x0403,
+	// MOT transport: 0x05xx
+	MOTCTTransportHeaderUpdate	= 0x0500,
+	MOTCTTransportHeaderOnly	= 0x0501,
+	// System: 0x06xx
+	MOTCTSystemMHEG			= 0x0600,
+	MOTCTSystemJava			= 0x0601,
+	// Application Specific: 0x07xx
+	MOTCTApplication		= 0x0700,
+	// Proprietary: 0x3fxx
+	MOTCTProprietary		= 0x3f00
+};
+
+/**
+ * Return the base type from the MOTContentType
+ */
+inline MOTContentBaseType getContentBaseType(MOTContentType ct) {
+	return static_cast<MOTContentBaseType>(
+			(ct & MOTCTBaseTypeMask)
+			>> 8
+	);
+}
+
+/**
+ * Return the sub type from the MOTContentType
+ */
+inline uint8_t getContentSubType(MOTContentType ct) {
+	return static_cast<uint8_t>(
+			(ct & MOTCTSubTypeMask)
+	);
+}
+
+#endif

--- a/includes/backend/data/mot/mot-handler.h
+++ b/includes/backend/data/mot/mot-handler.h
@@ -32,7 +32,7 @@ class	motDirectory;
 
 class	motHandler:public virtual_dataHandler {
 public:
-		motHandler	(RadioInterface *, QString );
+		motHandler	(RadioInterface *, const QString& );
 		~motHandler();
 	void	add_mscDatagroup	(std::vector<uint8_t>);
 private:

--- a/includes/backend/data/mot/mot-object.h
+++ b/includes/backend/data/mot/mot-object.h
@@ -73,7 +73,7 @@ private:
 	std::map<int, QByteArray> motMap;
 
 signals:
-        void	the_picture (QByteArray, MOTContentType, QString);
+        void	the_picture (QByteArray, uint16_t, QString);
 };
 
 #endif

--- a/includes/backend/data/mot/mot-object.h
+++ b/includes/backend/data/mot/mot-object.h
@@ -42,7 +42,7 @@ class	motObject: public QObject {
 Q_OBJECT
 public:
 		motObject (RadioInterface *mr,
-	                   QString	picturePath,
+	                   const QString& picturePath,
 	                   bool		dirElement,
 	                   uint16_t	transportId,
 	                   uint8_t	*segment,

--- a/includes/backend/data/mot/mot-object.h
+++ b/includes/backend/data/mot/mot-object.h
@@ -23,6 +23,7 @@
 #ifndef	__MOT_OBJECT__
 #define	__MOT_OBJECT__
 #include	"dab-constants.h"
+#include	"mot-content-types.h"
 #include	<QObject>
 #include	<QImage>
 #include	<QLabel>
@@ -63,8 +64,7 @@ private:
 	int32_t		segmentSize;
 	uint32_t	headerSize;
 	uint32_t	bodySize;
-	int		contentType;
-	int		contentsubType;
+	MOTContentType	contentType;
 	QString		name;
 	void		handleComplete();
 #ifdef	TRY_EPG
@@ -73,7 +73,7 @@ private:
 	std::map<int, QByteArray> motMap;
 
 signals:
-        void	the_picture (QByteArray, int, QString);
+        void	the_picture (QByteArray, MOTContentType, QString);
 };
 
 #endif

--- a/includes/backend/data/mot/mot-object.h
+++ b/includes/backend/data/mot/mot-object.h
@@ -73,7 +73,7 @@ private:
 	std::map<int, QByteArray> motMap;
 
 signals:
-        void	the_picture (QByteArray, uint16_t, QString);
+        void	the_picture (QByteArray, int, QString);
 };
 
 #endif

--- a/includes/backend/data/pad-handler.h
+++ b/includes/backend/data/pad-handler.h
@@ -34,7 +34,7 @@ class	motObject;
 class	padHandler: public QObject {
 Q_OBJECT
 public:
-		padHandler		(RadioInterface *, QString);
+		padHandler		(RadioInterface *, const QString&);
 		~padHandler();
 	void	processPAD		(uint8_t *, int16_t, uint8_t, uint8_t);
 private:

--- a/includes/backend/msc-handler.h
+++ b/includes/backend/msc-handler.h
@@ -47,7 +47,7 @@ Q_OBJECT
 public:
 			mscHandler		(RadioInterface *,
 	                                         uint8_t,
-	                                         QString,
+	                                         const QString&,
 	                                         RingBuffer<uint8_t> *);
 			~mscHandler();
 	void		processBlock_0		(std::complex<float> *);

--- a/src/backend/audio/mp2processor.cpp
+++ b/src/backend/audio/mp2processor.cpp
@@ -223,7 +223,7 @@ struct quantizer_spec quantizer_table [17] = {
 	                            int16_t		bitRate,
 	                            RingBuffer<int16_t> *buffer,
 	                            RingBuffer<uint8_t> *frameBuffer,
-	                            QString		picturesPath):
+	                            const QString&	picturesPath):
 	                                my_padhandler (mr, picturesPath) {
 int16_t	i, j;
 int16_t *nPtr = &N [0][0];

--- a/src/backend/audio/mp4processor.cpp
+++ b/src/backend/audio/mp4processor.cpp
@@ -46,7 +46,7 @@
 	                            int16_t		bitRate,
 	                            RingBuffer<int16_t> *b,
 	                            RingBuffer<uint8_t> *frameBuffer,
-	                            QString	picturesPath)
+	                            const QString&	picturesPath)
 	                               :my_padhandler (mr, picturesPath),
  	                                my_rsDecoder (8, 0435, 0, 1, 10) {
 

--- a/src/backend/backend-driver.cpp
+++ b/src/backend/backend-driver.cpp
@@ -32,7 +32,7 @@
 	                              RingBuffer<int16_t> *audioBuffer,
 	                              RingBuffer<uint8_t> *dataBuffer,
 	                              RingBuffer<uint8_t> *frameBuffer,
-	                              QString		picturesPath) {
+	                              const QString&	picturesPath) {
 	if (d -> type == AUDIO_SERVICE) {
 	   if (((audiodata *)d) -> ASCTy != 077) {
               theProcessor = new mp2Processor (mr,

--- a/src/backend/backend.cpp
+++ b/src/backend/backend.cpp
@@ -34,7 +34,7 @@
 	                         RingBuffer<int16_t> *audiobuffer,
 	                         RingBuffer<uint8_t> *databuffer,	
 	                         RingBuffer<uint8_t> *frameBuffer,
-	                         QString	picturesPath):
+	                         const QString&	picturesPath):
 	                                    outV (d -> bitRate * 24),
 	                                    driver (mr, 
 	                                            d,

--- a/src/backend/data/data-processor.cpp
+++ b/src/backend/data/data-processor.cpp
@@ -36,7 +36,7 @@
 	dataProcessor::dataProcessor	(RadioInterface *mr,
 	                                 packetdata	*pd,
 	                                 RingBuffer<uint8_t> *dataBuffer,
-	                                 QString	picturesPath) {
+	                                 const QString&	picturesPath) {
 	this	-> myRadioInterface	= mr;
 	this	-> bitRate		= pd -> bitRate;
 	this	-> DSCTy		= pd -> DSCTy;

--- a/src/backend/data/mot/mot-handler.cpp
+++ b/src/backend/data/mot/mot-handler.cpp
@@ -35,7 +35,7 @@ struct {
 } motTable [15];
 
 	motHandler::motHandler (RadioInterface *mr,
-	                        QString	picturesPath) {
+	                        const QString&	picturesPath) {
 	myRadioInterface	= mr;
 	this	-> picturesPath	= picturesPath;
 	orderNumber		= 0;

--- a/src/backend/data/mot/mot-object.cpp
+++ b/src/backend/data/mot/mot-object.cpp
@@ -153,10 +153,6 @@ QByteArray result;
 	for (const auto &it : motMap)
 	   result. append (it. second);
 
-	if (picturePath.isEmpty())
-	   /* No picture path given */
-	   return;
-
 	if (baseType == MOTBaseTypeApplication) {		// epg data
 #ifdef	TRY_EPG
 	   if (name == QString (""))
@@ -175,22 +171,24 @@ QByteArray result;
 //	Only send the picture to show when it is a slide and not
 //	an element of a directory
 	if ((baseType != MOTBaseTypeImage) || dirElement) {
-	   if (name == QString (""))
-	      name = "no name";
-	   QString realName = picturePath;
-	   realName. append (name);
-	   realName  = QDir::toNativeSeparators (realName);
-	   fprintf (stderr, "going to write file %s\n",
-	                         realName. toUtf8(). data());
-	   checkDir (realName);
-	   FILE *x = fopen (realName. toLatin1 (). data(), "w+b");
-	   if (x == nullptr)
-	      fprintf (stderr, "cannot write file %s\n",
-	                           realName. toUtf8(). data());
-	   else {
-	      (void)fwrite (result. data(), 1, bodySize, x);
-	      fclose (x);
-	   }
+		if (!picturePath.isEmpty()) {
+			if (name == QString (""))
+				name = "no name";
+			QString realName = picturePath;
+			realName. append (name);
+			realName  = QDir::toNativeSeparators (realName);
+			fprintf (stderr, "going to write file %s\n",
+					realName. toUtf8(). data());
+			checkDir (realName);
+			FILE *x = fopen (realName. toLatin1 (). data(), "w+b");
+			if (x == nullptr)
+				fprintf (stderr, "cannot write file %s\n",
+						realName. toUtf8(). data());
+			else {
+				(void)fwrite (result. data(), 1, bodySize, x);
+				fclose (x);
+			}
+		}
 	   return;
 	}
 

--- a/src/backend/data/mot/mot-object.cpp
+++ b/src/backend/data/mot/mot-object.cpp
@@ -37,8 +37,8 @@ uint16_t rawContentType = 0;
 
 	this	-> picturePath	= picturePath;
 	this	-> dirElement	= dirElement;
-	connect (this, SIGNAL (the_picture (QByteArray, MOTContentType, QString)),
-	         mr,   SLOT   (showMOT     (QByteArray, MOTContentType, QString)));
+	connect (this, SIGNAL (the_picture (QByteArray, uint16_t, QString)),
+	         mr,   SLOT   (showMOT     (QByteArray, uint16_t, QString)));
 	this	-> transportId		= transportId;
 	this	-> numofSegments	= -1;
 	this	-> segmentSize		= -1;
@@ -197,7 +197,7 @@ QByteArray result;
         else
 	   realName. append (name);
 	checkDir (realName);
-	the_picture (result, contentType, realName);
+	the_picture (result, static_cast<uint16_t>(contentType), realName);
 }
 
 void	motObject::checkDir (QString &s) {

--- a/src/backend/data/mot/mot-object.cpp
+++ b/src/backend/data/mot/mot-object.cpp
@@ -26,7 +26,7 @@
 #include	"radio.h"
 
 	   motObject::motObject (RadioInterface *mr,
-	                         QString	picturePath,
+	                         const QString& picturePath,
 	                         bool		dirElement,
 	                         uint16_t	transportId,
 	                         uint8_t	*segment,

--- a/src/backend/data/mot/mot-object.cpp
+++ b/src/backend/data/mot/mot-object.cpp
@@ -37,8 +37,8 @@ uint16_t rawContentType = 0;
 
 	this	-> picturePath	= picturePath;
 	this	-> dirElement	= dirElement;
-	connect (this, SIGNAL (the_picture (QByteArray, uint16_t, QString)),
-	         mr,   SLOT   (showMOT     (QByteArray, uint16_t, QString)));
+	connect (this, SIGNAL (the_picture (QByteArray, int, QString)),
+	         mr,   SLOT   (showMOT     (QByteArray, int, QString)));
 	this	-> transportId		= transportId;
 	this	-> numofSegments	= -1;
 	this	-> segmentSize		= -1;
@@ -201,7 +201,7 @@ QByteArray result;
         else
 	   realName. append (name);
 	checkDir (realName);
-	the_picture (result, static_cast<uint16_t>(contentType), realName);
+	the_picture (result, static_cast<int>(contentType), realName);
 }
 
 void	motObject::checkDir (QString &s) {

--- a/src/backend/data/mot/mot-object.cpp
+++ b/src/backend/data/mot/mot-object.cpp
@@ -153,6 +153,10 @@ QByteArray result;
 	for (const auto &it : motMap)
 	   result. append (it. second);
 
+	if (picturePath.isEmpty())
+	   /* No picture path given */
+	   return;
+
 	if (baseType == MOTBaseTypeApplication) {		// epg data
 #ifdef	TRY_EPG
 	   if (name == QString (""))

--- a/src/backend/data/pad-handler.cpp
+++ b/src/backend/data/pad-handler.cpp
@@ -28,7 +28,7 @@
   *	\class padHandler
   *	Handles the pad segments passed on from mp2- and mp4Processor
   */
-	padHandler::padHandler	(RadioInterface *mr, QString picturesPath) {
+	padHandler::padHandler	(RadioInterface *mr, const QString& picturesPath) {
 	myRadioInterface	= mr;
 	connect (this, SIGNAL (showLabel (QString)),
 	         mr, SLOT (showLabel (QString)));

--- a/src/backend/msc-handler.cpp
+++ b/src/backend/msc-handler.cpp
@@ -37,7 +37,7 @@ static int cifTable [] = {18, 72, 0, 36};
 //
 		mscHandler::mscHandler	(RadioInterface *mr,
 	                                 uint8_t	dabMode,
-	                                 QString	picturesPath,
+	                                 const QString&	picturesPath,
 	                                 RingBuffer<uint8_t> *frameBuffer) :
 	                                       params (dabMode),
 	                                       my_fftHandler (dabMode),


### PR DESCRIPTION
If MOT slideshows have been disabled (`showSlides=0`), the constructor for `motObject` receives an empty string for `picturePath`.  The code in `motObject` doesn't check for this condition and will blindly append the file name to this path producing a valid relative path, to which it writes the received file.

This code should check for an empty string in `picturePath`, and if found to be empty, skip writing the file to disk.

Whilst I was here, I also added an `enum` that defines all the content types to reduce the reliance on magic numbers.

Resolves issue #154.