### PR TITLE
Fix illegal memory access in fibDecoder::FIG1Extension1

### DIFF
--- a/src/ofdm/fib-decoder.cpp
+++ b/src/ofdm/fib-decoder.cpp
@@ -963,12 +963,12 @@ char		label [17];
 	                                  (const char *) label,
 	                                  (CharacterSet) charSet);
 	serviceIndex	= findService (dataName);
-	if (serviceIndex == -1) 
+	if (serviceIndex == -1) {
 	   createService (dataName, SId, 0);
-	else
+	} else {
 	  ensemble -> services [serviceIndex]. SCIds = 0;
-
-	ensemble -> services [serviceIndex]. hasName = true;
+	  ensemble -> services [serviceIndex]. hasName = true;
+	}
 }
 
 // service component label 8.1.14.3


### PR DESCRIPTION
If `serviceIndex == -1`, then the following does a write to non-allocated heap memory:
https://github.com/JvanKatwijk/qt-dab/blob/88beb2f0156c0822f76858bd1c27970236612c62/src/ofdm/fib-decoder.cpp#L974

In that case, it is also unnecessessary to set this value, as it is already set by `fibDecoder::createService`.