### PR TITLE
Build system

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ script:
   - ls -lh .
   - rm -rf *_autogen
   - mkdir -p appdir/usr/bin
-  - cp qt-dab-3.7  appdir/usr/bin/qt-dab
+  - cp qt-dab-*  appdir/usr/bin/qt-dab
  
   - mkdir -p appdir/usr/share/applications ; cp qt-dab.desktop appdir/usr/share/applications
   - cp qt-dab.png appdir/qt-dab.png

--- a/dab-maxi/CMakeLists.txt
+++ b/dab-maxi/CMakeLists.txt
@@ -690,7 +690,6 @@ endif ()
 	        ./qt-devices/pluto-handler-2/pluto-handler.cpp
 	   )
 
-	   list(APPEND extraLibs -liio)
 	   add_definitions (-DHAVE_PLUTO)
 	endif (PLUTO)
 #


### PR DESCRIPTION
* _Remove -liio from linker flags when using CMAKE_:
 When requesting support for PLUTO via CMAKE, it configures pluto-handler-2, which does not link against libiio but instead uses dlopen() to dynamically load the library at runtime. Remove the flag to make qt-dab compile with pluto-handler-2 enabled on
systems without libiio.
* _Fix CI build_
 The binary includes the version number. To avoid changing the travis config on each update, just use a wildcard.