### PR TITLE
Leave K loop in reedSolomon::computeLambda in time

### DIFF
--- a/src/backend/reed-solomon.cpp
+++ b/src/backend/reed-solomon.cpp
@@ -281,7 +281,7 @@ int16_t	deg_lambda;
 	Lambda	[0]	= 1;
 	Corrector [1]	= 1;
 //
-	while (K <= nroots) {
+	while (K < nroots) {
 	   uint8_t oldLambda [nroots];
 	   memcpy (oldLambda, Lambda, nroots * sizeof (Lambda [0]));
 //
@@ -310,6 +310,12 @@ int16_t	deg_lambda;
 	   }
 	   K += 1;
  	} // end of Berlekamp loop
+
+//	Compute final lambda
+	for (i = 0; i < nroots; i ++)
+	   Lambda [i] = myGalois. add_poly (Lambda [i],
+	                          myGalois. multiply_poly (error,
+	                                                   Corrector [i]));
 
 	for (i = 0; i < nroots; i ++) {
 	   if (Lambda [i] != 0)


### PR DESCRIPTION
So far, the loop ran as long as K <= nroots. In the last iteration, the
only relevant operation was the update of Lambda. All operations after
that have no relevance if there is no next iteration. However, that part
caused an invalid access into syndromes.

Let the loop run only as long K < nroots and do the final Lambda
calculation afterwards.

Fixes #202