### PR TITLE
Fix index computation in SpectrogramData::value

### DIFF
--- a/includes/scopes-qwt6/spectrogramdata.h
+++ b/includes/scopes-qwt6/spectrogramdata.h
@@ -75,7 +75,8 @@ QwtInterval Interval (Qt::Axis x)const {
 double value (double x, double y) const {
 //fprintf (stderr, "x = %f, y = %f\n", x, y);
 	   x = x - left;
-	   x = x / width * datawidth;
+	   x = x / width  * (datawidth  - 1);
+	   y = y / height * (dataheight - 1);
 	   return data [(int)y * datawidth + (int)x];
 }
 

--- a/src/ofdm/fib-decoder.cpp
+++ b/src/ofdm/fib-decoder.cpp
@@ -968,7 +968,6 @@ char		label [17];
 	serviceIndex	= findService (dataName);
 	if (serviceIndex == -1) {
 	   createService (dataName, SId, 0);
-	else 
 	} else {
 	  ensemble -> services [serviceIndex]. SCIds = 0;
 	  ensemble -> services [serviceIndex]. hasName = true;


### PR DESCRIPTION
data is of size datawidth*dataheight. The result of x/width and y/height may result in [0,1]. We therefore must multiply with (datawidth-1) and (dataheight-1) to stay within the bounds of data.

This PR also contains a small fix for what I think was a merge issue.