### PR TITLE
hackrf: allow setting LNA gain to 40

### DIFF
--- a/dab-2/devices-dab-2/hackrf-handler/hackrf-widget.ui
+++ b/dab-2/devices-dab-2/hackrf-handler/hackrf-widget.ui
@@ -190,7 +190,7 @@
          </sizepolicy>
         </property>
         <property name="maximum">
-         <number>39</number>
+         <number>40</number>
         </property>
         <property name="orientation">
          <enum>Qt::Vertical</enum>

--- a/dab-maxi/qt-devices/hackrf-handler/hackrf-widget.ui
+++ b/dab-maxi/qt-devices/hackrf-handler/hackrf-widget.ui
@@ -153,7 +153,7 @@
         </sizepolicy>
        </property>
        <property name="maximum">
-        <number>39</number>
+        <number>40</number>
        </property>
        <property name="orientation">
         <enum>Qt::Vertical</enum>


### PR DESCRIPTION
The bound is already correct in `hackrfHandler::setLNAGain`, just the UI did not allow setting this value.

Also see https://github.com/mossmann/hackrf/wiki/libHackRF-API