### PR TITLE
Fix delete of motComponents[i].motSlide in motDirectory::~motDirectory

### DIFF
--- a/src/backend/data/mot/mot-dir.cpp
+++ b/src/backend/data/mot/mot-dir.cpp
@@ -57,7 +57,7 @@ int	i;
 
 	for (i = 0; i < numObjects; i ++) 
 	   if (motComponents [i]. inUse)
-	      delete [] motComponents [i]. motSlide;
+	      delete motComponents [i]. motSlide;
 	delete []	motComponents;
 }
 


### PR DESCRIPTION
`motComponents[i].motSlide` is a single object of type `motObject`. Freeing it should be done with `delete` and not `delete[]`. Depending on the compiler and runtime used, `delete[]` can cause an invalid read left to the object.

Fixes #209