### PR TITLE
padHandler: verify data length

### DIFF
--- a/src/backend/data/pad-handler.cpp
+++ b/src/backend/data/pad-handler.cpp
@@ -193,6 +193,12 @@ std::vector<uint8_t> data;		// for the local addition
 //	the size of the latest xpadfield that had a CI_flag != 0
 	if (CI_flag == 0) {
 	   if (mscGroupElement && (xpadLength > 0)) {
+
+	      if (last < xpadLength) {
+	         fprintf(stderr, "handle_variablePAD: last < xpadLength\n");
+	         return;
+	      }
+
 	      data. resize (xpadLength);
 	      for (j = 0; j < xpadLength; j ++)
 	         data [j] = b [last - j];
@@ -407,6 +413,11 @@ void	padHandler::build_MSC_segment (std::vector<uint8_t> data) {
 //	is
 int32_t	size	= data. size() < (uint32_t)dataGroupLength ? data. size() :
 	                                            dataGroupLength;
+
+if (size < 2) {
+	fprintf (stderr, "build_MSC_segment: data size < 2\n");
+	return;
+}
 	   
 uint8_t		groupType	=  data [0] & 0xF;
 //uint8_t	continuityIndex = (data [1] & 0xF0) >> 4;


### PR DESCRIPTION
Address sanitizer revealed some more invalid memory accesses:

## 1. `check_crc_bytes` may be called with negative `len`

```
=================================================================
==113255==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x60200032c92e at pc 0x560584674e16 bp 0x7f48944c19f0 sp 0x7f48944c19e0
READ of size 1 at 0x60200032c92e thread T57 (dabProcessor)
    #0 0x560584674e15 in padHandler::build_MSC_segment(std::vector<unsigned char, std::allocator<unsigned char> >) /home/bevan/git/qt-dab/dab-maxi/../includes/dab-constants.h:380
    #1 0x560584675233 in padHandler::new_MSC_element(std::vector<unsigned char, std::allocator<unsigned char> >) /home/bevan/git/qt-dab/src/backend/data/pad-handler.cpp:371
    #2 0x56058467f5e7 in padHandler::handle_variablePAD(unsigned char*, short, unsigned char) /home/bevan/git/qt-dab/src/backend/data/pad-handler.cpp:251
    #3 0x560584654f5b in mp4Processor::processSuperframe(unsigned char*, short) /home/bevan/git/qt-dab/src/backend/data/pad-handler.cpp:85
    #4 0x560584655f60 in mp4Processor::addtoFrame(std::vector<unsigned char, std::allocator<unsigned char> >) /home/bevan/git/qt-dab/src/backend/audio/mp4processor.cpp:138
    #5 0x560584648a5c in backendDriver::addtoFrame(std::vector<unsigned char, std::allocator<unsigned char> >) /home/bevan/git/qt-dab/src/backend/backend-driver.cpp:66
    #6 0x560584649248 in Backend::processSegment(short*) /home/bevan/git/qt-dab/src/backend/backend.cpp:146
    #7 0x560584649719 in Backend::process(short*, short) /home/bevan/git/qt-dab/src/backend/backend.cpp:114
    #8 0x560584649719 in mscHandler::process_mscBlock(std::vector<short, std::allocator<short> >, short) /home/bevan/git/qt-dab/src/backend/msc-handler.cpp:294
    #9 0x560584649719 in mscHandler::process_mscBlock(std::vector<short, std::allocator<short> >, short) /home/bevan/git/qt-dab/src/backend/msc-handler.cpp:269
    #10 0x560584649d1d in mscHandler::process_Msc(std::complex<float>*, int) /home/bevan/git/qt-dab/src/backend/msc-handler.cpp:188
    #11 0x56058461ffda in dabProcessor::run() /home/bevan/git/qt-dab/dab-processor.cpp:307
    #12 0x7f48cb94a08e  (/usr/lib/libQt5Core.so.5+0xce08e)
    #13 0x7f48cc528298 in start_thread (/usr/lib/libpthread.so.0+0x9298)
    #14 0x7f48cb470052 in __GI___clone (/usr/lib/libc.so.6+0xff052)

0x60200032c92e is located 2 bytes to the left of 4-byte region [0x60200032c930,0x60200032c934)
allocated by thread T57 (dabProcessor) here:
    #0 0x7f48cd3f9f41 in operator new(unsigned long) /build/gcc/src/gcc/libsanitizer/asan/asan_new_delete.cpp:99
    #1 0x560584675182 in padHandler::new_MSC_element(std::vector<unsigned char, std::allocator<unsigned char> >) /usr/include/c++/10.2.0/ext/new_allocator.h:115

Thread T57 (dabProcessor) created by T0 here:
    #0 0x7f48cd39e1c7 in __interceptor_pthread_create /build/gcc/src/gcc/libsanitizer/asan/asan_interceptors.cpp:214
    #1 0x7f48cb949b22 in QThread::start(QThread::Priority) (/usr/lib/libQt5Core.so.5+0xcdb22)

SUMMARY: AddressSanitizer: heap-buffer-overflow /home/bevan/git/qt-dab/dab-maxi/../includes/dab-constants.h:380 in padHandler::build_MSC_segment(std::vector<unsigned char, std::allocator<unsigned char> >)
Shadow bytes around the buggy address:
  0x0c048005d8d0: fa fa fd fd fa fa fd fd fa fa fd fd fa fa fd fa
  0x0c048005d8e0: fa fa fd fd fa fa fa fa fa fa fd fa fa fa fd fa
  0x0c048005d8f0: fa fa fd fa fa fa fd fa fa fa fd fa fa fa fd fd
  0x0c048005d900: fa fa fd fa fa fa fd fd fa fa fd fa fa fa fd fd
  0x0c048005d910: fa fa fd fd fa fa 00 04 fa fa fd fd fa fa fd fa
=>0x0c048005d920: fa fa fd fd fa[fa]04 fa fa fa fd fa fa fa fd fa
  0x0c048005d930: fa fa fd fa fa fa fd fd fa fa fd fa fa fa fa fa
  0x0c048005d940: fa fa fd fa fa fa fd fd fa fa fd fd fa fa fd fa
  0x0c048005d950: fa fa fd fa fa fa fd fa fa fa fd fd fa fa fd fa
  0x0c048005d960: fa fa fd fd fa fa fd fd fa fa fd fd fa fa fd fd
  0x0c048005d970: fa fa fd fd fa fa fd fd fa fa fd fa fa fa fd fd
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07 
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
  Shadow gap:              cc
==113255==ABORTING
```

If `padHandler::build_MSC_segment` is called with a `data` vector that has less than two elements, `size` will be negative and `check_crc_bytes` is called with a negative `len` argument. This then leads to an invalid access in https://github.com/JvanKatwijk/qt-dab/blob/c59f0f924e5808b9f5d9ad9a223c22d22c254872/includes/dab-constants.h#L380

## 2. `padHandler::handle_variablePAD` computes negative offsets into `b` if `last < xpadLength`

```
=================================================================
==114103==ERROR: AddressSanitizer: dynamic-stack-buffer-overflow on address 0x7efd49c9ed3f at pc 0x5617459eeb95 bp 0x7efd49c9eb80 sp 0x7efd49c9eb70
READ of size 1 at 0x7efd49c9ed3f thread T47 (dabProcessor)
    #0 0x5617459eeb94 in padHandler::handle_variablePAD(unsigned char*, short, unsigned char) /home/bevan/git/qt-dab/src/backend/data/pad-handler.cpp:198
    #1 0x5617459c3f9b in mp4Processor::processSuperframe(unsigned char*, short) /home/bevan/git/qt-dab/src/backend/data/pad-handler.cpp:85
    #2 0x5617459c4fa0 in mp4Processor::addtoFrame(std::vector<unsigned char, std::allocator<unsigned char> >) /home/bevan/git/qt-dab/src/backend/audio/mp4processor.cpp:138
    #3 0x5617459b7a9c in backendDriver::addtoFrame(std::vector<unsigned char, std::allocator<unsigned char> >) /home/bevan/git/qt-dab/src/backend/backend-driver.cpp:66
    #4 0x5617459b8288 in Backend::processSegment(short*) /home/bevan/git/qt-dab/src/backend/backend.cpp:146
    #5 0x5617459b8759 in Backend::process(short*, short) /home/bevan/git/qt-dab/src/backend/backend.cpp:114
    #6 0x5617459b8759 in mscHandler::process_mscBlock(std::vector<short, std::allocator<short> >, short) /home/bevan/git/qt-dab/src/backend/msc-handler.cpp:294
    #7 0x5617459b8759 in mscHandler::process_mscBlock(std::vector<short, std::allocator<short> >, short) /home/bevan/git/qt-dab/src/backend/msc-handler.cpp:269
    #8 0x5617459b8d5d in mscHandler::process_Msc(std::complex<float>*, int) /home/bevan/git/qt-dab/src/backend/msc-handler.cpp:188
    #9 0x56174598f01a in dabProcessor::run() /home/bevan/git/qt-dab/dab-processor.cpp:307
    #10 0x7efd8112f08e  (/usr/lib/libQt5Core.so.5+0xce08e)
    #11 0x7efd81d0d298 in start_thread (/usr/lib/libpthread.so.0+0x9298)
    #12 0x7efd80c55052 in __GI___clone (/usr/lib/libc.so.6+0xff052)

Address 0x7efd49c9ed3f is located in stack of thread T47 (dabProcessor) at offset 335 in frame
    #0 0x5617459ed7df in padHandler::handle_variablePAD(unsigned char*, short, unsigned char) /home/bevan/git/qt-dab/src/backend/data/pad-handler.cpp:184

  This frame has 3 object(s):
    [32, 56) 'data' (line 189)
    [96, 120) '<unknown>'
    [160, 164) 'CI_table' (line 186) <== Memory access at offset 335 overflows this variable
HINT: this may be a false positive if your program uses some custom stack unwind mechanism, swapcontext or vfork
      (longjmp and C++ exceptions *are* supported)
Thread T47 (dabProcessor) created by T0 here:
    #0 0x7efd82b831c7 in __interceptor_pthread_create /build/gcc/src/gcc/libsanitizer/asan/asan_interceptors.cpp:214
    #1 0x7efd8112eb22 in QThread::start(QThread::Priority) (/usr/lib/libQt5Core.so.5+0xcdb22)

SUMMARY: AddressSanitizer: dynamic-stack-buffer-overflow /home/bevan/git/qt-dab/src/backend/data/pad-handler.cpp:198 in padHandler::handle_variablePAD(unsigned char*, short, unsigned char)
Shadow bytes around the buggy address:
  0x0fe02938bd50: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x0fe02938bd60: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x0fe02938bd70: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 f1 f1
  0x0fe02938bd80: f1 f1 00 00 00 f2 f2 f2 f2 f2 00 00 00 f2 f2 f2
  0x0fe02938bd90: f2 f2 04 f3 f3 f3 00 00 00 00 00 00 00 00 00 00
=>0x0fe02938bda0: 00 00 00 00 ca ca ca[ca]00 00 00 00 00 00 cb cb
  0x0fe02938bdb0: cb cb cb cb 00 00 00 00 00 00 00 00 00 00 00 00
  0x0fe02938bdc0: 00 00 00 00 00 00 00 00 00 00 f1 f1 f1 f1 f1 f1
  0x0fe02938bdd0: 01 f2 04 f2 00 00 00 f2 f2 f2 f2 f2 00 00 00 00
  0x0fe02938bde0: 04 f2 f2 f2 f2 f2 00 00 f2 f2 00 00 00 00 00 00
  0x0fe02938bdf0: 00 00 00 00 00 00 00 06 f2 f2 f2 f2 00 00 00 00
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07 
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
  Shadow gap:              cc
==114103==ABORTING
```

### Reproducers
* I cannot reproduce issue 1 anymore since I applied a fix for issue 2. So maybe this was just a follow-up error, actually caused by issue 2. But the additional verification also does not hurt.
* I have a raw recording that triggers issue 2 due to bad reception. File name: `hackRF-11D-Do--Mai-13-12-37-44-2021.sdr`, tune into 1LIVE. The error is triggered short before the end of the recording.
* Interestingly, there are channels that constantly trigger issue 2, even on good reception. So maybe there is an additional issue somewhere? I have a reproducer for that as well. File name: `hackRF-5D-Do--Mai-13-12-28-54-2021.sdr`, tune into one of the "Absolute ..." channels.
I will share links to those files via email. Uploading them will take some time...