### PR TITLE
padHandler: correct valid range for last

### DIFF
--- a/src/backend/data/pad-handler.cpp
+++ b/src/backend/data/pad-handler.cpp
@@ -194,8 +194,8 @@ std::vector<uint8_t> data;		// for the local addition
 	if (CI_flag == 0) {
 	   if (mscGroupElement && (xpadLength > 0)) {
 
-	      if (last < xpadLength) {
-	         fprintf(stderr, "handle_variablePAD: last < xpadLength\n");
+	      if (last < xpadLength - 1) {
+	         fprintf(stderr, "handle_variablePAD: last < xpadLength - 1\n");
 	         return;
 	      }
 


### PR DESCRIPTION
Oops. The fact that some channels constantly trigger the error condition introduced in #212 should have made me suspicious. There was an off-by-one error in that patch.

I'm currently still testing if this still solves the bug shown by the sanitizer.