### PR TITLE
hackrf: update gain display when restoring settings

### DIFF
--- a/dab-maxi/qt-dab.pro
+++ b/dab-maxi/qt-dab.pro
@@ -346,7 +346,6 @@ CONFIG		+= PC
 #CONFIG		+= RPI
 #DEFINES	+= SHOW_MISSING
 DEFINES		+= __DUMP_SNR__		# for experiments only
-DEFINES		+=__KEEP_GAIN_SETTINGS__
 }
 
 
@@ -430,7 +429,6 @@ CONFIG		+= faad
 
 CONFIG		+= try-epg		# do not use
 DEFINES	+= __DUMP_SNR__		# for experiments only
-DEFINES		+=__KEEP_GAIN_SETTINGS__
 }
 #	devices
 #

--- a/dab-maxi/qt-devices/hackrf-handler/hackrf-handler.cpp
+++ b/dab-maxi/qt-devices/hackrf-handler/hackrf-handler.cpp
@@ -208,8 +208,12 @@ int	res;
 	         AmpEnableButton, SLOT (setChecked (bool)));
 	connect (this, SIGNAL (new_vgaValue (int)),
 		 vgaGainSlider, SLOT (setValue (int)));
+	connect (this, SIGNAL (new_vgaValue (int)),
+		 vgagainDisplay, SLOT (display (int)));
 	connect (this, SIGNAL (new_lnaValue (int)),
 	         lnaGainSlider, SLOT (setValue (int)));
+	connect (this, SIGNAL (new_lnaValue (int)),
+	         lnagainDisplay, SLOT (display (int)));
 	xmlDumper	= nullptr;
 	dumping. store (false);
 	running. store (false);


### PR DESCRIPTION
So far, only the sliders are updated and not the LCD type numeric displays. Since signal emission is disabled during restore, the updates do not automatically propagate to the numeric displays.

**This issue may also affect other qt-devices.** However, I cannot test them.

This commit also removes leftover definitions of `__KEEP_GAIN_SETTINGS__` in `qt-dab.pro` since this setting is gone since qt-dab 3.5.