### PR TITLE
Add missing #include <QPen> in several files

### DIFF
--- a/correlation-viewer/correlation-viewer.cpp
+++ b/correlation-viewer/correlation-viewer.cpp
@@ -24,6 +24,7 @@
 #include	"correlation-viewer.h"
 #include	<QSettings>
 #include	<QColor>
+#include	<QPen>
 #include	"color-selector.h"
 
 	correlationViewer::correlationViewer	(RadioInterface	*mr,

--- a/snr-viewer/snr-viewer.cpp
+++ b/snr-viewer/snr-viewer.cpp
@@ -26,6 +26,7 @@
 #include	"snr-viewer.h"
 #include	<QSettings>
 #include	<QColor>
+#include	<QPen>
 #include	<string.h>
 #include	"color-selector.h"
 

--- a/spectrum-viewer/spectrum-viewer.cpp
+++ b/spectrum-viewer/spectrum-viewer.cpp
@@ -25,6 +25,7 @@
 #include	<QSettings>
 #include	"iqdisplay.h"
 #include	<QColor>
+#include	<QPen>
 #include	"color-selector.h"
 
 	spectrumViewer::spectrumViewer	(RadioInterface	*mr,

--- a/tii-viewer/tii-viewer.cpp
+++ b/tii-viewer/tii-viewer.cpp
@@ -24,6 +24,7 @@
 #include	"tii-viewer.h"
 #include	"iqdisplay.h"
 #include	<QColor>
+#include	<QPen>
 #include	"color-selector.h"
 
 	tiiViewer::tiiViewer	(RadioInterface	*mr,


### PR DESCRIPTION
This fails when building with Qt 5.12.2 and Qwt 6.2.0; it was probably transitively included by another header in earlier versions.