### PR TITLE
Fixed German special chars in console

### DIFF
--- a/dab-maxi/radio.cpp
+++ b/dab-maxi/radio.cpp
@@ -2783,7 +2783,7 @@ void	RadioInterface::start_audioService (audiodata *ad) {
 	QDateTime theDateTime	= QDateTime::currentDateTime ();
 	QTime theTime		= theDateTime. time ();
 	fprintf (stderr, "we start %s at %.2d:%.2d\n",
-	                        ad -> serviceName. toLatin1 (). data (),
+	                        ad -> serviceName. toUtf8 (). data (),
 	                        theTime. hour (), theTime. minute ());
 	serviceLabel -> setAlignment(Qt::AlignCenter);
 	serviceLabel -> setText (ad -> serviceName);

--- a/src/backend/backend.cpp
+++ b/src/backend/backend.cpp
@@ -59,7 +59,7 @@ int32_t i, j;
 	this	-> subChId		= d -> subchId;
 
 	fprintf (stderr, "starting a backend for %s (%X)\n",
-	                  serviceName. toLatin1 (). data (), serviceId);
+	                  serviceName. toUtf8 (). data (), serviceId);
 	interleaveData. resize (16);
 	for (i = 0; i < 16; i ++) {
 	   interleaveData [i]. resize (fragmentSize);


### PR DESCRIPTION
```
we start j�.live          at 13:30
starting a backend for j�.live          (AD56)
```
become 
```
we start jö.live          at 13:44
starting a backend for jö.live          (AD56)
```