### PR TITLE
EPG detection for SLO, UK, CH, SWE, DK

### DIFF
--- a/dab-maxi/radio.cpp
+++ b/dab-maxi/radio.cpp
@@ -4060,6 +4060,11 @@ void	RadioInterface::epgTimer_timeOut	() {
 	for (const auto serv : serviceList) {
 	   if (serv. name. contains ("-EPG ", Qt::CaseInsensitive) ||
 	       serv. name. contains (" EPG   ", Qt::CaseInsensitive) ||
+               serv. name. contains ("Spored", Qt::CaseInsensitive) ||
+               serv. name. contains ("NivaaEPG", Qt::CaseInsensitive) ||
+               serv. name. contains ("SPI", Qt::CaseSensitive) ||
+               serv. name. contains ("BBC Guide", Qt::CaseInsensitive) ||
+               serv. name. contains ("EPG_", Qt::CaseInsensitive) ||
 	       serv. name. startsWith ("EPG ", Qt::CaseInsensitive) ) {
 	      packetdata pd;
 	      my_dabProcessor -> dataforPacketService (serv. name, &pd, 0);


### PR DESCRIPTION
Enables EPG (resp. SPI) detection for data services (using unusual names) in 

- Slovenia (Spored)
- Denmark (NivaaEPG)
- Sweden (SPI), remark: made search string case sensitive, otherwise *Inspire* is identified as *SPI*
- Switzerland (SRG_SPI and RMS_SPI)
- UK (BBC Guide)
- Italy (EuroDAB started EPG_SI recently)

for example:
```
Starting hidden service BBC Guide       
starting a backend for BBC Guide        (E1C79E5E)
dirSize 6239, numObjects 180, segmentSize 500
```

```
Starting hidden service Spored          
starting a backend for Spored           (E4910002)
dirSize 91, numObjects 2, segmentSize 91
```
```
Starting hidden service SRG_SPI         
starting a backend for SRG_SPI          (E1400103)
```

Note: This fix does not improve the EPG feature itself.