### PR TITLE
Revert "Save EPG slides again"

### DIFF
--- a/dab-maxi/radio.cpp
+++ b/dab-maxi/radio.cpp
@@ -966,7 +966,7 @@ QString realName;
 	      break;
 
 	   case MOTBaseTypeImage:
-	      if (dirElement == 1)
+	      if (dirElement == 0)
 	         show_MOTlabel (result, contentType, name, dirElement);
 	      break;
 


### PR DESCRIPTION
Reverts JvanKatwijk/qt-dab#239

I'm very sorry Jan, I found out that setting that to `1` prevents Qt-DAB from showing (and saving) SLS slides in general. That's not, what people expect ...

Let's set the parameter again to `0`. 