### PR TITLE
Showing Slides and (!) EPG slides

### DIFF
--- a/dab-maxi/radio.cpp
+++ b/dab-maxi/radio.cpp
@@ -968,6 +968,8 @@ QString realName;
 	   case MOTBaseTypeImage:
 	      if (dirElement == 1)
 	         show_MOTlabel (result, contentType, name, dirElement);
+	      if (dirElement == 0)
+	         show_MOTlabel (result, contentType, name, dirElement);
 	      break;
 
 	   case MOTBaseTypeAudio:


### PR DESCRIPTION
When 1 + 0 are given, the slides are displayed (and saved) and (!) the EPG slides are saved.