### PR TITLE
mac support

### DIFF
--- a/dab-maxi/http-handler.cpp
+++ b/dab-maxi/http-handler.cpp
@@ -24,7 +24,7 @@
 #include	<stdio.h>
 #include	<stdlib.h>
 #include	<unistd.h>
-#include	<sys/types.h> 
+#include	<sys/types.h>
 #ifndef	__MINGW32__
 #include	<sys/socket.h>
 #include	<fcntl.h>
@@ -44,48 +44,48 @@
 
 #include	"converted_map.h"
 
-	httpHandler::httpHandler (RadioInterface *parent, int port,
-	                          std::complex<float> address,
-	                          bool autoBrowser_off,
-	                          const QString &browserAddress) {
-	this	-> parent	= parent;
-	this	-> port		= port;
-	this	-> homeAddress	= address;
-	this	-> autoBrowser_off	= autoBrowser_off;
+    httpHandler::httpHandler (RadioInterface *parent, int port,
+                              std::complex<float> address,
+                              bool autoBrowser_off,
+                              const QString &browserAddress) {
+    this	-> parent	= parent;
+    this	-> port		= port;
+    this	-> homeAddress	= address;
+    this	-> autoBrowser_off	= autoBrowser_off;
 #ifdef	__MINGW32__
-	this	-> browserAddress	= browserAddress. toStdWString ();
+    this	-> browserAddress	= browserAddress. toStdWString ();
 #else
-	this	-> browserAddress	= browserAddress. toStdString ();
+    this	-> browserAddress	= browserAddress. toStdString ();
 #endif
-	this	-> running. store (false);
-	connect (this, SIGNAL (terminating ()),
-	         parent, SLOT (http_terminate ()));
-	start ();
+    this	-> running. store (false);
+    connect (this, SIGNAL (terminating ()),
+             parent, SLOT (http_terminate ()));
+    start ();
 }
 
 
-	httpHandler::~httpHandler	() {
-	if (running. load ()) {
-	   running. store (false);
-	   threadHandle. join ();
-	}
+    httpHandler::~httpHandler	() {
+    if (running. load ()) {
+       running. store (false);
+       threadHandle. join ();
+    }
 }
 
 void	httpHandler::start	() {
-	threadHandle = std::thread (&httpHandler::run, this);
-	if (autoBrowser_off)
-	   return;
+    threadHandle = std::thread (&httpHandler::run, this);
+    if (autoBrowser_off)
+       return;
 #ifdef	__MINGW32__
-	ShellExecute (NULL, L"open", browserAddress. c_str (),
-	                                       NULL, NULL, SW_SHOWNORMAL);
+    ShellExecute (NULL, L"open", browserAddress. c_str (),
+                                           NULL, NULL, SW_SHOWNORMAL);
 #else
-	std::string x = "xdg-open " + browserAddress;
-	system (x. c_str ());
+    std::string x = "xdg-open " + browserAddress;
+    system (x. c_str ());
 #endif
 }
 
 void	httpHandler::stop	() {
-	if (running. load ()) {
+    if (running. load ()) {
            running. store (false);
            threadHandle. join ();
         }
@@ -101,115 +101,115 @@ struct sockaddr_in svr_addr, cli_addr;
 std::string	content;
 std::string	ctype;
 
-	running. store (true);
-	socklen_t sin_len = sizeof (cli_addr);
-	ListenSocket = socket (AF_INET, SOCK_STREAM, 0);
-	if (ListenSocket < 0) {
-	   running. store (false);
-	   terminating ();
-	   return;
-	}
+    running. store (true);
+    socklen_t sin_len = sizeof (cli_addr);
+    ListenSocket = socket (AF_INET, SOCK_STREAM, 0);
+    if (ListenSocket < 0) {
+       running. store (false);
+       terminating ();
+       return;
+    }
 
-	int flags	= fcntl (ListenSocket, F_GETFL);
-	fcntl (ListenSocket, F_SETFL, flags | O_NONBLOCK);
-	setsockopt (ListenSocket, SOL_SOCKET, SO_REUSEADDR, &one, sizeof(int));
-	svr_addr.sin_family = AF_INET;
-	svr_addr.sin_addr.s_addr = INADDR_ANY;
-	svr_addr.sin_port = htons (port);
- 
-	if (bind (ListenSocket, (struct sockaddr *) &svr_addr,
-	                                  sizeof (svr_addr)) == -1) {
-	   close (ListenSocket);
-	   running. store (false);
-	   terminating ();
-	   return;
-	}
+    int flags	= fcntl (ListenSocket, F_GETFL);
+    fcntl (ListenSocket, F_SETFL, flags | O_NONBLOCK);
+    setsockopt (ListenSocket, SOL_SOCKET, SO_REUSEADDR, &one, sizeof(int));
+    svr_addr.sin_family = AF_INET;
+    svr_addr.sin_addr.s_addr = INADDR_ANY;
+    svr_addr.sin_port = htons (port);
+
+    if (::bind (ListenSocket, (struct sockaddr *) &svr_addr,
+                                      sizeof (svr_addr)) == -1) {
+       close (ListenSocket);
+       running. store (false);
+       terminating ();
+       return;
+    }
 //
 //	Now, we are listening to port 8080, ready to accept a
 //	socket for anyone who needs us
 
-	listen (ListenSocket, 5);
-	while (running. load ()) {
-	   ClientSocket = accept (ListenSocket,
-	                    (struct sockaddr *) &cli_addr, &sin_len);
-	   if (ClientSocket == -1) {
-	      usleep (2000000);
-	      continue;
-	   }
+    ::listen (ListenSocket, 5);
+    while (running. load ()) {
+       ClientSocket = accept (ListenSocket,
+                        (struct sockaddr *) &cli_addr, &sin_len);
+       if (ClientSocket == -1) {
+          usleep (2000000);
+          continue;
+       }
 //
 //	someone needs us, let us see what (s)he wants
-	   while (running. load ()) {
-	      if (read (ClientSocket, buffer, 4096) < 0) {
-	         running. store (false);
-	         break;
-	      }
+       while (running. load ()) {
+          if (read (ClientSocket, buffer, 4096) < 0) {
+             running. store (false);
+             break;
+          }
 
 //	      fprintf (stderr, "Buffer - %s\n", buffer);
-	      int httpver = (strstr (buffer, "HTTP/1.1") != NULL) ? 11 : 10;
-	      if (httpver == 11) 
-//	HTTP 1.1 defaults to keep-alive, unless close is specified. 
-	         keepalive = strstr (buffer, "Connection: close") == NULL;
-	      else // httpver == 10
-	         keepalive = strstr (buffer, "Connection: keep-alive") != NULL;
+          int httpver = (strstr (buffer, "HTTP/1.1") != NULL) ? 11 : 10;
+          if (httpver == 11)
+//	HTTP 1.1 defaults to keep-alive, unless close is specified.
+             keepalive = strstr (buffer, "Connection: close") == NULL;
+          else // httpver == 10
+             keepalive = strstr (buffer, "Connection: keep-alive") != NULL;
 
 /*	Identify the URL. */
-	      char *p = strchr (buffer, ' ');
-	      if (p == NULL) 
-	         break;
-	      url = ++p; // Now this should point to the requested URL. 
-	      p = strchr (p, ' ');
-	      if (p == NULL)
-	         break;
-	      *p = '\0';
+          char *p = strchr (buffer, ' ');
+          if (p == NULL)
+             break;
+          url = ++p; // Now this should point to the requested URL.
+          p = strchr (p, ' ');
+          if (p == NULL)
+             break;
+          *p = '\0';
 
 //	Select the content to send, we have just two so far:
 //	 "/" -> Our google map application.
 //	 "/data.json" -> Our ajax request to update planes. */
-	      bool jsonUpdate	= false;
-	      if (strstr (url, "/data.json")) {
-	         content	= coordinatesToJson (transmitterList);
-	         if (content != "") {
-	            ctype	= "application/json;charset=utf-8";
-	            jsonUpdate	= true;
-	         }
-	      }
-	      else {
-	         content	= theMap (homeAddress);
-	         ctype		= "text/html;charset=utf-8";
-	      }
+          bool jsonUpdate	= false;
+          if (strstr (url, "/data.json")) {
+             content	= coordinatesToJson (transmitterList);
+             if (content != "") {
+                ctype	= "application/json;charset=utf-8";
+                jsonUpdate	= true;
+             }
+          }
+          else {
+             content	= theMap (homeAddress);
+             ctype		= "text/html;charset=utf-8";
+          }
 
-//	Create the header 
-	      char hdr [2048];
-	      sprintf (hdr,
-	               "HTTP/1.1 200 OK\r\n"
-	               "Server: qt-dab\r\n"
-	               "Content-Type: %s\r\n"
-	               "Connection: %s\r\n"
-	               "Content-Length: %d\r\n"
+//	Create the header
+          char hdr [2048];
+          sprintf (hdr,
+                   "HTTP/1.1 200 OK\r\n"
+                   "Server: qt-dab\r\n"
+                   "Content-Type: %s\r\n"
+                   "Connection: %s\r\n"
+                   "Content-Length: %d\r\n"
 //	               "Access-Control-Allow-Origin: *\r\n"
-	               "\r\n",
-	               ctype. c_str (),
-	               keepalive ? "keep-alive" : "close",
-	               (int)(strlen (content. c_str ())));
-	      int hdrlen = strlen (hdr);
+                   "\r\n",
+                   ctype. c_str (),
+                   keepalive ? "keep-alive" : "close",
+                   (int)(strlen (content. c_str ())));
+          int hdrlen = strlen (hdr);
 //	      fprintf (stderr, "reply header %s \n", hdr);
-	      if (jsonUpdate) {
+          if (jsonUpdate) {
 //	         fprintf (stderr, "Json update requested\n");
 //	         fprintf (stderr, "%s\n", content. c_str ());
-	      }
+          }
 //	and send the reply
-	      if (write (ClientSocket, hdr, hdrlen) != hdrlen ||
-	          write (ClientSocket, content. c_str (),
-	                          content. size ()) != content. size ())  {
+          if (write (ClientSocket, hdr, hdrlen) != hdrlen ||
+              write (ClientSocket, content. c_str (),
+                              content. size ()) != content. size ())  {
 //	         fprintf (stderr, "WRITE PROBLEM\n");
 //	         break;
-	      }
-	   }
-	}
-	fprintf (stderr, "mapServer quits\n");
-	close (ListenSocket);
-	close (ClientSocket);
-	emit terminating ();
+          }
+       }
+    }
+    fprintf (stderr, "mapServer quits\n");
+    close (ListenSocket);
+    close (ClientSocket);
+    emit terminating ();
 }
 #else
 //
@@ -229,154 +229,154 @@ SOCKET	ClientSocket	= INVALID_SOCKET;
 struct addrinfo *result = NULL;
 struct addrinfo hints;
 
-	if (WSAStartup (MAKEWORD (2, 2), &wsa) != 0) {
-	   terminating ();
-	   return;
-	}
+    if (WSAStartup (MAKEWORD (2, 2), &wsa) != 0) {
+       terminating ();
+       return;
+    }
 
-	ZeroMemory (&hints, sizeof(hints));
-	hints.ai_family		= AF_INET;
-	hints.ai_socktype	= SOCK_STREAM;
-	hints.ai_protocol	= IPPROTO_TCP;
-	hints.ai_flags		= AI_PASSIVE;
+    ZeroMemory (&hints, sizeof(hints));
+    hints.ai_family		= AF_INET;
+    hints.ai_socktype	= SOCK_STREAM;
+    hints.ai_protocol	= IPPROTO_TCP;
+    hints.ai_flags		= AI_PASSIVE;
 
 //	Resolve the server address and port
-	
-	iResult = getaddrinfo (NULL, "8080", &hints, &result);
-	if (iResult != 0 ) {
+
+    iResult = getaddrinfo (NULL, "8080", &hints, &result);
+    if (iResult != 0 ) {
            WSACleanup();
-	   terminating ();
-	   return;
-	}
+       terminating ();
+       return;
+    }
 
 // Create a SOCKET for connecting to server
-	ListenSocket = socket (result -> ai_family,
-	                       result -> ai_socktype, result -> ai_protocol);
-	if (ListenSocket == INVALID_SOCKET) {
-	   freeaddrinfo(result);
-	   WSACleanup ();
-	   terminating ();
-	   return;
-	}
-	unsigned long mode = 1;
-	ioctlsocket (ListenSocket, FIONBIO, &mode);
+    ListenSocket = socket (result -> ai_family,
+                           result -> ai_socktype, result -> ai_protocol);
+    if (ListenSocket == INVALID_SOCKET) {
+       freeaddrinfo(result);
+       WSACleanup ();
+       terminating ();
+       return;
+    }
+    unsigned long mode = 1;
+    ioctlsocket (ListenSocket, FIONBIO, &mode);
 
 // Setup the TCP listening socket
-	iResult = bind (ListenSocket, result -> ai_addr,
-	                                (int)result->ai_addrlen);
-	if (iResult == SOCKET_ERROR) {
-	   freeaddrinfo (result);
-	   closesocket (ListenSocket);
-	   WSACleanup ();
-	   terminating ();
-	   return;
-	}
+    iResult = bind (ListenSocket, result -> ai_addr,
+                                    (int)result->ai_addrlen);
+    if (iResult == SOCKET_ERROR) {
+       freeaddrinfo (result);
+       closesocket (ListenSocket);
+       WSACleanup ();
+       terminating ();
+       return;
+    }
 
-	freeaddrinfo (result);
+    freeaddrinfo (result);
 
-	running. store (true);
+    running. store (true);
 
-	listen (ListenSocket, 5);
-	while (running. load ()) {
-	   ClientSocket = accept (ListenSocket, NULL, NULL);
-	   if (ClientSocket == -1)  {
-	      usleep (2000000);
-	      continue;
-	   }
-	   
-	   while (running. load ()) {
-	      int xx;
+    listen (ListenSocket, 5);
+    while (running. load ()) {
+       ClientSocket = accept (ListenSocket, NULL, NULL);
+       if (ClientSocket == -1)  {
+          usleep (2000000);
+          continue;
+       }
+
+       while (running. load ()) {
+          int xx;
 L1:	      if ((xx = recv (ClientSocket, buffer, 4096, 0)) < 0) {
 // shutdown the connection since we're done
-	         iResult = shutdown (ClientSocket, SD_SEND);
-	         if (iResult == SOCKET_ERROR) {
-	            closesocket (ClientSocket);
-				closesocket (ListenSocket);
-	            WSACleanup ();
-	            running.store (false);
-	            terminating ();
-	            return;
-	         }
-	         break;
-	      }
-	      if (xx == 0) {
-	         if (!running. load ()) {
-	            closesocket (ClientSocket);
-				closesocket(ListenSocket);
-	            WSACleanup ();
-	            terminating ();
-	            return;
-	         }
-	         Sleep (1);
-	         goto L1;
-	      }
-	           
-	      int httpver = (strstr (buffer, "HTTP/1.1") != NULL) ? 11 : 10;
-	      if (httpver == 11) 
-//	HTTP 1.1 defaults to keep-alive, unless close is specified. 
-	         keepalive = strstr (buffer, "Connection: close") == NULL;
-	      else // httpver == 10
-	         keepalive = strstr (buffer, "Connection: keep-alive") != NULL;
+             iResult = shutdown (ClientSocket, SD_SEND);
+             if (iResult == SOCKET_ERROR) {
+                closesocket (ClientSocket);
+                closesocket (ListenSocket);
+                WSACleanup ();
+                running.store (false);
+                terminating ();
+                return;
+             }
+             break;
+          }
+          if (xx == 0) {
+             if (!running. load ()) {
+                closesocket (ClientSocket);
+                closesocket(ListenSocket);
+                WSACleanup ();
+                terminating ();
+                return;
+             }
+             Sleep (1);
+             goto L1;
+          }
 
-	/* Identify the URL. */
-	      char *p = strchr (buffer, ' ');
-	      if (p == NULL) 
-	         break;
-	      url = ++p; // Now this should point to the requested URL. 
-	      p = strchr (p, ' ');
-	      if (p == NULL)
-	         break;
-	      *p = '\0';
+          int httpver = (strstr (buffer, "HTTP/1.1") != NULL) ? 11 : 10;
+          if (httpver == 11)
+//	HTTP 1.1 defaults to keep-alive, unless close is specified.
+             keepalive = strstr (buffer, "Connection: close") == NULL;
+          else // httpver == 10
+             keepalive = strstr (buffer, "Connection: keep-alive") != NULL;
+
+    /* Identify the URL. */
+          char *p = strchr (buffer, ' ');
+          if (p == NULL)
+             break;
+          url = ++p; // Now this should point to the requested URL.
+          p = strchr (p, ' ');
+          if (p == NULL)
+             break;
+          *p = '\0';
 
 //	Select the content to send, we have just two so far:
 //	 "/" -> Our google map application.
 //	 "/data.json" -> Our ajax request to update transmitters. */
-	      bool jsonUpdate	= false;
-	      if (strstr (url, "/data.json")) {
-	         content	= coordinatesToJson (transmitterList);
-	         if (content != "") {
-	            ctype	= "application/json;charset=utf-8";
-	            jsonUpdate	= true;
+          bool jsonUpdate	= false;
+          if (strstr (url, "/data.json")) {
+             content	= coordinatesToJson (transmitterList);
+             if (content != "") {
+                ctype	= "application/json;charset=utf-8";
+                jsonUpdate	= true;
 //	            fprintf (stderr, "%s will be sent\n", content. c_str ());
-	         }
-	      }
-	      else {
-	         content	= theMap (homeAddress);
-	         ctype		= "text/html;charset=utf-8";
-	      }
-//	Create the header 
-	      char hdr [2048];
-	      sprintf (hdr,
-	               "HTTP/1.1 200 OK\r\n"
-	               "Server: SDRunoPlugin_1090\r\n"
-	               "Content-Type: %s\r\n"
-	               "Connection: %s\r\n"
-	               "Content-Length: %d\r\n"
+             }
+          }
+          else {
+             content	= theMap (homeAddress);
+             ctype		= "text/html;charset=utf-8";
+          }
+//	Create the header
+          char hdr [2048];
+          sprintf (hdr,
+                   "HTTP/1.1 200 OK\r\n"
+                   "Server: SDRunoPlugin_1090\r\n"
+                   "Content-Type: %s\r\n"
+                   "Connection: %s\r\n"
+                   "Content-Length: %d\r\n"
 //	               "Access-Control-Allow-Origin: *\r\n"
-	               "\r\n",
-	               ctype. c_str (),
-	               keepalive ? "keep-alive" : "close",
-	               (int)(strlen (content. c_str ())));
-	      int hdrlen = strlen (hdr);
+                   "\r\n",
+                   ctype. c_str (),
+                   keepalive ? "keep-alive" : "close",
+                   (int)(strlen (content. c_str ())));
+          int hdrlen = strlen (hdr);
 //	      if (jsonUpdate) {
 //	         parent -> show_text (std::string ("Json update requested\n"));
 //	         parent -> show_text (content);
 //	      }
 //	and send the reply
-	      if ((send (ClientSocket, hdr, hdrlen, 0) == SOCKET_ERROR) ||
-	          (send (ClientSocket, content. c_str (),
-	                          content. size (), 0) == SOCKET_ERROR))  {
-	         fprintf (stderr, "WRITE PROBLEM\n");
-	         break;
-	      }
-	   }
-	}
+          if ((send (ClientSocket, hdr, hdrlen, 0) == SOCKET_ERROR) ||
+              (send (ClientSocket, content. c_str (),
+                              content. size (), 0) == SOCKET_ERROR))  {
+             fprintf (stderr, "WRITE PROBLEM\n");
+             break;
+          }
+       }
+    }
 // cleanup
-	closesocket(ClientSocket);
-	closesocket(ListenSocket);
-	WSACleanup();
-	running. store (false);
-	emit	terminating ();
+    closesocket(ClientSocket);
+    closesocket(ListenSocket);
+    WSACleanup();
+    running. store (false);
+    emit	terminating ();
 }
 #endif
 
@@ -389,42 +389,42 @@ std::string longitude	= std::to_string (imag (homeAddress));
 int	index		= 0;
 int	cc;
 
-	bodySize	= sizeof (qt_map);
+    bodySize	= sizeof (qt_map);
         body =  (char *)malloc (bodySize + 40);
-	int teller	= 0;
-	int params	= 0;
-	while (qt_map [index] != 0) {
-	   cc =  (char)(qt_map [index]);
-	   if (cc == '$') {
-	      if (params == 0) {
-	         for (int i = 0; latitude. c_str () [i] != 0; i ++)
-	            if (latitude. c_str () [i] == ',')
-	               body [teller ++] = '.';
-	            else
-	               body [teller ++] = latitude. c_str () [i];
-	         params ++;
-	      }
-	      else
-	      if (params == 1) {
-	         for (int i = 0; longitude. c_str () [i] != 0; i ++)
-	            if (longitude. c_str () [i] == ',')
-	               body [teller ++] = '.';
-	            else
-	            body [teller ++] = longitude. c_str () [i];
-	         params ++;
-	      }
-	      else
-	         body [teller ++] = (char)cc;
-	   }
-	   else
-	      body [teller ++] = (char)cc;
-	   index ++;
-	}
-	body [teller ++] = 0;
-	res	= std::string (body);
+    int teller	= 0;
+    int params	= 0;
+    while (qt_map [index] != 0) {
+       cc =  (char)(qt_map [index]);
+       if (cc == '$') {
+          if (params == 0) {
+             for (int i = 0; latitude. c_str () [i] != 0; i ++)
+                if (latitude. c_str () [i] == ',')
+                   body [teller ++] = '.';
+                else
+                   body [teller ++] = latitude. c_str () [i];
+             params ++;
+          }
+          else
+          if (params == 1) {
+             for (int i = 0; longitude. c_str () [i] != 0; i ++)
+                if (longitude. c_str () [i] == ',')
+                   body [teller ++] = '.';
+                else
+                body [teller ++] = longitude. c_str () [i];
+             params ++;
+          }
+          else
+             body [teller ++] = (char)cc;
+       }
+       else
+          body [teller ++] = (char)cc;
+       index ++;
+    }
+    body [teller ++] = 0;
+    res	= std::string (body);
 //	fprintf (stderr, "The map :\n%s\n", res. c_str ());
-	free (body);
-	return res;
+    free (body);
+    return res;
 }
 
 std::string dotNumber (float f) {
@@ -445,61 +445,61 @@ std::complex<float> target = std::complex<float> (0, 0);
 char buf [512];
 QString Jsontxt;
 
-	if (t. size () == 0)
-	   return "";
-	Jsontxt += "[\n";
-	locker. lock ();
+    if (t. size () == 0)
+       return "";
+    Jsontxt += "[\n";
+    locker. lock ();
 //	the Target
-	snprintf (buf, 512, 
-	          "{\"type\":%d, \"lat\":%s, \"lon\":%s, \"name\":\"%s\", \"channel\":\"%s\", \"dist\":%d, \"azimuth\":%d}",
-	           t [0]. type,
-	           dotNumber (real (t [0]. coords)). c_str (),
-	           dotNumber (imag (t [0]. coords)). c_str (),
-	           t [0]. transmitterName. toUtf8 (). data (),
-	           t [0]. channelName. toUtf8 (). data (),
-	           t [0]. distance,
-	           t [0]. azimuth);
-	Jsontxt += QString (buf);
+    snprintf (buf, 512,
+              "{\"type\":%d, \"lat\":%s, \"lon\":%s, \"name\":\"%s\", \"channel\":\"%s\", \"dist\":%d, \"azimuth\":%d}",
+               t [0]. type,
+               dotNumber (real (t [0]. coords)). c_str (),
+               dotNumber (imag (t [0]. coords)). c_str (),
+               t [0]. transmitterName. toUtf8 (). data (),
+               t [0]. channelName. toUtf8 (). data (),
+               t [0]. distance,
+               t [0]. azimuth);
+    Jsontxt += QString (buf);
 //
-//	
-	for (int i = 1; i < t. size (); i ++) {
-	   snprintf (buf, 512, 
-	          ",\n{\"type\":%d, \"lat\":%s, \"lon\":%s, \"name\":\"%s\", \"channel\":\"%s\", \"dist\":%d, \"azimuth\":%d}",
-	            t [i]. type,
-	            dotNumber (real (t [i]. coords)). c_str (),
-	            dotNumber (imag (t [i]. coords)). c_str (),
-	            t [i]. transmitterName. toUtf8 (). data (),
-	            t [i]. channelName. toUtf8 (). data (),
-	            t [i]. distance,
-	            t [i]. azimuth);
-	   Jsontxt += QString (buf);
-	}
-	t. resize (0);
-	locker. unlock ();
-	Jsontxt += "\n]\n";
+//
+    for (unsigned long i = 1; i < t. size (); i ++) {
+       snprintf (buf, 512,
+              ",\n{\"type\":%d, \"lat\":%s, \"lon\":%s, \"name\":\"%s\", \"channel\":\"%s\", \"dist\":%d, \"azimuth\":%d}",
+                t [i]. type,
+                dotNumber (real (t [i]. coords)). c_str (),
+                dotNumber (imag (t [i]. coords)). c_str (),
+                t [i]. transmitterName. toUtf8 (). data (),
+                t [i]. channelName. toUtf8 (). data (),
+                t [i]. distance,
+                t [i]. azimuth);
+       Jsontxt += QString (buf);
+    }
+    t. resize (0);
+    locker. unlock ();
+    Jsontxt += "\n]\n";
 //	fprintf (stderr, "Json = %s\n", Jsontxt. toLatin1 (). data ());
-	return Jsontxt. toStdString ();
+    return Jsontxt. toStdString ();
 }
 
 void	httpHandler::putData	(uint8_t	type,
-	                         std::complex<float> target,
-	                         QString transmitterName,
-	                         QString channelName,
-	                         int distance,
-	                         int azimuth) {
-	for (int i = 0; i < transmitterList. size (); i ++)
-	   if (transmitterList [i]. coords == target)
-	      return;
-	     
-	httpData t;
-	t. type			= type;
-	t. coords		= target;
-	t. transmitterName	= transmitterName;
-	t. channelName		= channelName;
-	t. distance		= distance;
-	t. azimuth		= azimuth;
-	locker. lock ();
-	transmitterList. push_back (t);
-	locker. unlock ();
+                             std::complex<float> target,
+                             QString transmitterName,
+                             QString channelName,
+                             int distance,
+                             int azimuth) {
+    for (unsigned long i = 0; i < transmitterList. size (); i ++)
+       if (transmitterList [i]. coords == target)
+          return;
+
+    httpData t;
+    t. type			= type;
+    t. coords		= target;
+    t. transmitterName	= transmitterName;
+    t. channelName		= channelName;
+    t. distance		= distance;
+    t. azimuth		= azimuth;
+    locker. lock ();
+    transmitterList. push_back (t);
+    locker. unlock ();
 }
 

--- a/dab-maxi/qt-dab.pro
+++ b/dab-maxi/qt-dab.pro
@@ -310,37 +310,57 @@ isEmpty(GITHASHSTRING) {
     DEFINES += GITHASH=\\\"------\\\"
 }
 
+mac {
+  DESTDIR      = ./mac-bin
+  PKG_CONFIG = /usr/local/bin/pkg-config
+}
+
+QT_CONFIG	-= no-pkg-config
 CONFIG		+= link_pkgconfig
 PKGCONFIG	+= fftw3f 
 PKGCONFIG	+= sndfile
 PKGCONFIG	+= samplerate
 PKGCONFIG	+= libusb-1.0
 CONFIG		+= mapserver
+!mac {
+LIBS      	+= -ldl
+}
+PKGCONFIG	+= portaudio-2.0
+PKGCONFIG	+= zlib
+PKGCONFIG	+= sndfile
+PKGCONFIG	+= samplerate
 INCLUDEPATH	+= /usr/local/include
-INCLUDEPATH	+= /usr/local/include /usr/include/qt4/qwt /usr/include/qt5/qwt /usr/include/qt4/qwt /usr/include/qwt /usr/local/qwt-6.1.4-svn/
-LIBS		+= -lportaudio
-LIBS		+= -lz -ldl
+!mac {
+INCLUDEPATH	+= /usr/local/include
 #correct this for the correct path to the qwt6 library on your system
 #LIBS		+= -lqwt
-LIBS		+= -lqwt-qt5
+#LIBS		+= -lqwt-qt5
+}
+
+#mac {
+# Should be possible to make on non Macs as well.
+# qmake -set QMAKEFEATURES /usr/local/Cellar/qwt/6.2.0/features
+CONFIG		+= qwt
+#}
+
 #
 # comment or uncomment for the devices you want to have support for
 # (you obviously have libraries installed for the selected ones)
-CONFIG		+= sdrplay-v2
-CONFIG		+= sdrplay-v3	
+#CONFIG		+= sdrplay-v2
+#CONFIG		+= sdrplay-v3
 CONFIG		+= dabstick
 CONFIG		+= rtl_tcp
-CONFIG		+= airspy
+#CONFIG		+= airspy
 CONFIG		+= hackrf
-CONFIG		+= lime
-CONFIG		+= soapy
+#CONFIG		+= lime
+#CONFIG		+= soapy
 #CONFIG		+= pluto-rxtx
 #CONFIG		+= pluto
-CONFIG		+= pluto-2
+#CONFIG		+= pluto-2
 #CONFIG		+= elad-device
 #CONFIG		+= colibri
-CONFIG		+= faad
-#CONFIG		+= fdk-aac
+#CONFIG		+= faad
+CONFIG		+= fdk-aac
 #CONFIG		+= JAN
 #CONFIG		+= preCompiled
 CONFIG		+= tiiLib
@@ -725,7 +745,7 @@ faad	{
 	DEFINES		+= __WITH_FAAD__
 	HEADERS		+= ../includes/backend/audio/faad-decoder.h 
 	SOURCES		+= ../src/backend/audio/faad-decoder.cpp 
-	LIBS		+= -lfaad
+	PKGCONFIG	+= faad2
 }
 
 fdk-aac	{
@@ -733,7 +753,7 @@ fdk-aac	{
 	INCLUDEPATH	+= ../specials/fdk-aac
 	HEADERS		+= ../includes/backend/audio/fdk-aac.h 
 	SOURCES		+= ../src/backend/audio/fdk-aac.cpp 
-	LIBS		+= -lfdk-aac
+	PKGCONFIG	+= fdk-aac
 }
 
 JAN	{

--- a/dab-maxi/qt-devices/hackrf-handler/hackrf-handler.cpp
+++ b/dab-maxi/qt-devices/hackrf-handler/hackrf-handler.cpp
@@ -48,26 +48,21 @@ int	res;
 
 #ifdef  __MINGW32__
         const char *libraryString = "libhackrf.dll";
-        Handle          = LoadLibrary ((wchar_t *)L"libhackrf.dll");
-#elif  __clang__
-        const char *libraryString = "/opt/local/lib/libhackrf.dylib";
-        Handle = dlopen(libraryString,RTLD_NOW);
-#else
+#elif __linux__
         const char *libraryString = "libhackrf.so.0";
-        Handle          = dlopen (libraryString, RTLD_NOW);
+#elif __APPLE__
+        const char *libraryString = "libhackrf.dylib";
 #endif
+        phandle = new QLibrary(libraryString);
+        phandle->load();
 
-	if (Handle == nullptr) {
+	if (!phandle->isLoaded()) {
 	   fprintf (stderr, "failed to open %s\n", libraryString);
 	   throw (20);
 	}
 
-        if (!load_hackrfFunctions()) {
-#ifdef __MINGW32__
-           FreeLibrary (Handle);
-#else
-           dlclose (Handle);
-#endif
+        if (!load_hackrfFunctions ()) {
+           delete phandle;
            throw (21);
         }
 //
@@ -446,136 +441,134 @@ QString	hackrfHandler::deviceName	() {
 bool	hackrfHandler::load_hackrfFunctions() {
 //
 //	link the required procedures
-	this -> hackrf_init	= (pfn_hackrf_init)
-	                       GETPROCADDRESS (Handle, "hackrf_init");
+    this -> hackrf_init	= (pfn_hackrf_init) phandle->resolve("hackrf_init");
 	if (this -> hackrf_init == nullptr) {
 	   fprintf (stderr, "Could not find hackrf_init\n");
 	   return false;
 	}
 
-	this -> hackrf_open	= (pfn_hackrf_open)
-	                       GETPROCADDRESS (Handle, "hackrf_open");
+    this -> hackrf_open	= (pfn_hackrf_open)
+                           phandle->resolve("hackrf_open");
 	if (this -> hackrf_open == nullptr) {
 	   fprintf (stderr, "Could not find hackrf_open\n");
 	   return false;
 	}
 
-	this -> hackrf_close	= (pfn_hackrf_close)
-	                       GETPROCADDRESS (Handle, "hackrf_close");
+    this -> hackrf_close	= (pfn_hackrf_close)
+                           phandle->resolve("hackrf_close");
 	if (this -> hackrf_close == nullptr) {
 	   fprintf (stderr, "Could not find hackrf_close\n");
 	   return false;
 	}
 
-	this -> hackrf_exit	= (pfn_hackrf_exit)
-	                       GETPROCADDRESS (Handle, "hackrf_exit");
+    this -> hackrf_exit	= (pfn_hackrf_exit)
+                           phandle->resolve("hackrf_exit");
 	if (this -> hackrf_exit == nullptr) {
 	   fprintf (stderr, "Could not find hackrf_exit\n");
 	   return false;
 	}
 
-	this -> hackrf_start_rx	= (pfn_hackrf_start_rx)
-	                       GETPROCADDRESS (Handle, "hackrf_start_rx");
+    this -> hackrf_start_rx	= (pfn_hackrf_start_rx)
+                           phandle->resolve("hackrf_start_rx");
 	if (this -> hackrf_start_rx == nullptr) {
 	   fprintf (stderr, "Could not find hackrf_start_rx\n");
 	   return false;
 	}
 
-	this -> hackrf_stop_rx	= (pfn_hackrf_stop_rx)
-	                       GETPROCADDRESS (Handle, "hackrf_stop_rx");
+    this -> hackrf_stop_rx	= (pfn_hackrf_stop_rx)
+                           phandle->resolve("hackrf_stop_rx");
 	if (this -> hackrf_stop_rx == nullptr) {
 	   fprintf (stderr, "Could not find hackrf_stop_rx\n");
 	   return false;
 	}
 
-	this -> hackrf_device_list	= (pfn_hackrf_device_list)
-	                       GETPROCADDRESS (Handle, "hackrf_device_list");
+    this -> hackrf_device_list	= (pfn_hackrf_device_list)
+                           phandle->resolve("hackrf_device_list");
 	if (this -> hackrf_device_list == nullptr) {
 	   fprintf (stderr, "Could not find hackrf_device_list\n");
 	   return false;
 	}
 
-	this -> hackrf_set_baseband_filter_bandwidth	=
-	                      (pfn_hackrf_set_baseband_filter_bandwidth)
-	                      GETPROCADDRESS (Handle,
-	                         "hackrf_set_baseband_filter_bandwidth");
+    this -> hackrf_set_baseband_filter_bandwidth	=
+                          (pfn_hackrf_set_baseband_filter_bandwidth)
+                          phandle->resolve("hackrf_set_baseband_filter_bandwidth");
 	if (this -> hackrf_set_baseband_filter_bandwidth == nullptr) {
 	   fprintf (stderr, "Could not find hackrf_set_baseband_filter_bandwidth\n");
 	   return false;
 	}
 
-	this -> hackrf_set_lna_gain	= (pfn_hackrf_set_lna_gain)
-	                       GETPROCADDRESS (Handle, "hackrf_set_lna_gain");
+    this -> hackrf_set_lna_gain	= (pfn_hackrf_set_lna_gain)
+                           phandle->resolve("hackrf_set_lna_gain");
 	if (this -> hackrf_set_lna_gain == nullptr) {
 	   fprintf (stderr, "Could not find hackrf_set_lna_gain\n");
 	   return false;
 	}
 
-	this -> hackrf_set_vga_gain	= (pfn_hackrf_set_vga_gain)
-	                       GETPROCADDRESS (Handle, "hackrf_set_vga_gain");
+    this -> hackrf_set_vga_gain	= (pfn_hackrf_set_vga_gain)
+                           phandle->resolve("hackrf_set_vga_gain");
 	if (this -> hackrf_set_vga_gain == nullptr) {
 	   fprintf (stderr, "Could not find hackrf_set_vga_gain\n");
 	   return false;
 	}
 
-	this -> hackrf_set_freq	= (pfn_hackrf_set_freq)
-	                       GETPROCADDRESS (Handle, "hackrf_set_freq");
+    this -> hackrf_set_freq	= (pfn_hackrf_set_freq)
+                           phandle->resolve("hackrf_set_freq");
 	if (this -> hackrf_set_freq == nullptr) {
 	   fprintf (stderr, "Could not find hackrf_set_freq\n");
 	   return false;
 	}
 
-	this -> hackrf_set_sample_rate	= (pfn_hackrf_set_sample_rate)
-	                       GETPROCADDRESS (Handle, "hackrf_set_sample_rate");
+    this -> hackrf_set_sample_rate	= (pfn_hackrf_set_sample_rate)
+                           phandle->resolve("hackrf_set_sample_rate");
 	if (this -> hackrf_set_sample_rate == nullptr) {
 	   fprintf (stderr, "Could not find hackrf_set_sample_rate\n");
 	   return false;
 	}
 
-	this -> hackrf_is_streaming	= (pfn_hackrf_is_streaming)
-	                       GETPROCADDRESS (Handle, "hackrf_is_streaming");
+    this -> hackrf_is_streaming	= (pfn_hackrf_is_streaming)
+                           phandle->resolve("hackrf_is_streaming");
 	if (this -> hackrf_is_streaming == nullptr) {
 	   fprintf (stderr, "Could not find hackrf_is_streaming\n");
 	   return false;
 	}
 
-	this -> hackrf_error_name	= (pfn_hackrf_error_name)
-	                       GETPROCADDRESS (Handle, "hackrf_error_name");
+    this -> hackrf_error_name	= (pfn_hackrf_error_name)
+                           phandle->resolve("hackrf_error_name");
 	if (this -> hackrf_error_name == nullptr) {
 	   fprintf (stderr, "Could not find hackrf_error_name\n");
 	   return false;
 	}
 
-	this -> hackrf_usb_board_id_name = (pfn_hackrf_usb_board_id_name)
-	                       GETPROCADDRESS (Handle, "hackrf_usb_board_id_name");
+    this -> hackrf_usb_board_id_name = (pfn_hackrf_usb_board_id_name)
+                           phandle->resolve("hackrf_usb_board_id_name");
 	if (this -> hackrf_usb_board_id_name == nullptr) {
 	   fprintf (stderr, "Could not find hackrf_usb_board_id_name\n");
 	   return false;
 	}
 // Aggiunta Fabio
 	this -> hackrf_set_antenna_enable = (pfn_hackrf_set_antenna_enable)
-	                  GETPROCADDRESS (Handle, "hackrf_set_antenna_enable");
+                      phandle->resolve("hackrf_set_antenna_enable");
 	if (this -> hackrf_set_antenna_enable == nullptr) {
 	   fprintf (stderr, "Could not find hackrf_set_antenna_enable\n");
 	   return false;
 	}
 
 	this -> hackrf_set_amp_enable = (pfn_hackrf_set_amp_enable)
-	                  GETPROCADDRESS (Handle, "hackrf_set_amp_enable");
+                      phandle->resolve("hackrf_set_amp_enable");
 	if (this -> hackrf_set_amp_enable == nullptr) {
 	   fprintf (stderr, "Could not find hackrf_set_amp_enable\n");
 	   return false;
 	}
 
 	this -> hackrf_si5351c_read = (pfn_hackrf_si5351c_read)
-	                 GETPROCADDRESS (Handle, "hackrf_si5351c_read");
+                     phandle->resolve("hackrf_si5351c_read");
 	if (this -> hackrf_si5351c_read == nullptr) {
 	   fprintf (stderr, "Could not find hackrf_si5351c_read\n");
 	   return false;
 	}
 
 	this -> hackrf_si5351c_write = (pfn_hackrf_si5351c_write)
-	                 GETPROCADDRESS (Handle, "hackrf_si5351c_write");
+                     phandle->resolve("hackrf_si5351c_write");
 	if (this -> hackrf_si5351c_write == nullptr) {
 	   fprintf (stderr, "Could not find hackrf_si5351c_write\n");
 	   return false;

--- a/dab-maxi/qt-devices/hackrf-handler/hackrf-handler.h
+++ b/dab-maxi/qt-devices/hackrf-handler/hackrf-handler.h
@@ -36,6 +36,7 @@
 #include	"device-handler.h"
 #include	"ui_hackrf-widget.h"
 #include	"libhackrf/hackrf.h"
+#include	<QLibrary>
 
 typedef int (*hackrf_sample_block_cb_fn)(hackrf_transfer *transfer);
 
@@ -137,7 +138,7 @@ private:
 	int32_t			inputRate;
 	int32_t			vfoFrequency;
 	std::atomic<bool>	running;
-	HINSTANCE		Handle;
+	QLibrary*		phandle;
 
 	FILE			*xmlDumper;
         xml_fileWriter		*xmlWriter;

--- a/dab-maxi/qt-devices/rtlsdr-handler/rtlsdr-handler.cpp
+++ b/dab-maxi/qt-devices/rtlsdr-handler/rtlsdr-handler.cpp
@@ -143,28 +143,21 @@ char	manufac [256], product [256], serial [256];
 	isActive		= false;
 #ifdef	__MINGW32__
 	const char *libraryString	= "librtlsdr.dll";
-	Handle		= LoadLibrary ((wchar_t *)L"librtlsdr.dll");
-	if (Handle == nullptr) 
-	   Handle = LoadLibrary ((wchar_t *)L"rtlsdr.dll");
-	if (Handle == nullptr) {
-	   fprintf (stderr, "failed to open %s (%d)\n", libraryString, GetLastError());
-	   throw (20);
-	}
-#else
-	const char *libraryString	= "librtlsdr.so";
-	Handle			= dlopen ("librtlsdr.so", RTLD_NOW);
+#elif __linux__
+    const char *libraryString	= "librtlsdr.so";
+#elif __APPLE__
+    const char *libraryString	= "librtlsdr.dylib";
+#endif
+    phandle = new QLibrary(libraryString);
+    phandle->load();
 
-	if (Handle == nullptr) {
-	   fprintf (stderr, "failed to open %s (%s)\n", libraryString, dlerror());
-	   throw (20);
-	}
-#endif
+    if (!phandle->isLoaded()) {
+       fprintf (stderr, "failed to open %s\n", libraryString);
+       throw (20);
+    }
+
 	if (!load_rtlFunctions()) {
-#ifdef __MINGW32__
-	   FreeLibrary (Handle);
-#else
-	   dlclose (Handle);
-#endif
+       delete (phandle);
 	   throw (21);
 	}
 
@@ -172,11 +165,7 @@ char	manufac [256], product [256], serial [256];
 	deviceCount 		= this -> rtlsdr_get_device_count ();
 	if (deviceCount == 0) {
 	   fprintf (stderr, "No devices found\n");
-#ifdef __MINGW32__
-	   FreeLibrary (Handle);
-#else
-	   dlclose (Handle);
-#endif
+       delete (phandle);
 	   throw (22);
 	}
 
@@ -194,11 +183,7 @@ char	manufac [256], product [256], serial [256];
 	r		= this -> rtlsdr_open (&device, deviceIndex);
 	if (r < 0) {
 	   fprintf (stderr, "Opening rtlsdr device failed\n");
-#ifdef __MINGW32__
-	   FreeLibrary (Handle);
-#else
-	   dlclose (Handle);
-#endif
+       delete phandle;
 	   throw (23);
 	}
 
@@ -207,13 +192,8 @@ char	manufac [256], product [256], serial [256];
 	r		= this -> rtlsdr_set_sample_rate (device, inputRate);
 	if (r < 0) {
 	   fprintf (stderr, "Setting samplerate failed\n");
-	   rtlsdr_close (device);
-#ifdef __MINGW32__
-	   FreeLibrary (Handle);
-#else
-	   dlclose (Handle);
-#endif
-	   throw (24);
+       delete phandle;
+       throw (24);
 	}
 
 	gainsCount = rtlsdr_get_tuner_gains (device, nullptr);
@@ -288,8 +268,8 @@ char	manufac [256], product [256], serial [256];
 	xml_dumping. store (false);
 }
 
-	rtlsdrHandler::~rtlsdrHandler () {
-	if (Handle == nullptr) {	// nothing achieved earlier on
+	rtlsdrHandler::~rtlsdrHandler() {
+    if (phandle == nullptr) {	// nothing achieved earlier on
 	   return;
 	}
 	stopReader	();
@@ -313,11 +293,7 @@ char	manufac [256], product [256], serial [256];
 	rtlsdrSettings	-> endGroup();
 	usleep (1000);
 	this		-> rtlsdr_close (device);
-#ifdef __MINGW32__
-	FreeLibrary (Handle);
-#else
-	dlclose (Handle);
-#endif
+    delete phandle;
 }
 
 void	rtlsdrHandler::setVFOFrequency	(int32_t f) {
@@ -430,44 +406,41 @@ int32_t	rtlsdrHandler::Samples() {
 bool	rtlsdrHandler::load_rtlFunctions() {
 //
 //	link the required procedures
-	rtlsdr_open	= (pfnrtlsdr_open)
-	                       GETPROCADDRESS (Handle, "rtlsdr_open");
+    rtlsdr_open	= (pfnrtlsdr_open) phandle->resolve ("rtlsdr_open");
 	if (rtlsdr_open == nullptr) {
 	   fprintf (stderr, "Could not find rtlsdr_open\n");
 	   return false;
 	}
 
-	rtlsdr_close	= (pfnrtlsdr_close)
-	                     GETPROCADDRESS (Handle, "rtlsdr_close");
+    rtlsdr_close	= (pfnrtlsdr_close) phandle->resolve ("rtlsdr_close");
 	if (rtlsdr_close == nullptr) {
 	   fprintf (stderr, "Could not find rtlsdr_close\n");
 	   return false;
 	}
 
 	rtlsdr_get_usb_strings =
-	    (pfnrtlsdr_get_usb_strings)
-	    GETPROCADDRESS (Handle, "rtlsdr_get_usb_strings");
+        (pfnrtlsdr_get_usb_strings) phandle->resolve("rtlsdr_get_usb_strings");
 	if (rtlsdr_get_usb_strings == nullptr) {
 	   fprintf (stderr, "Could not find rtlsdr_get_usb_strings\n");
 	   return false;
 	}
 
 	rtlsdr_set_sample_rate =
-	    (pfnrtlsdr_set_sample_rate)GETPROCADDRESS (Handle, "rtlsdr_set_sample_rate");
+        (pfnrtlsdr_set_sample_rate) phandle->resolve("rtlsdr_set_sample_rate");
 	if (rtlsdr_set_sample_rate == nullptr) {
 	   fprintf (stderr, "Could not find rtlsdr_set_sample_rate\n");
 	   return false;
 	}
 
 	rtlsdr_get_sample_rate	=
-	    (pfnrtlsdr_get_sample_rate)GETPROCADDRESS (Handle, "rtlsdr_get_sample_rate");
+        (pfnrtlsdr_get_sample_rate) phandle->resolve("rtlsdr_get_sample_rate");
 	if (rtlsdr_get_sample_rate == nullptr) {
 	   fprintf (stderr, "Could not find rtlsdr_get_sample_rate\n");
 	   return false;
 	}
 
 	rtlsdr_get_tuner_gains		= (pfnrtlsdr_get_tuner_gains)
-	                     GETPROCADDRESS (Handle, "rtlsdr_get_tuner_gains");
+                         phandle->resolve("rtlsdr_get_tuner_gains");
 	if (rtlsdr_get_tuner_gains == nullptr) {
 	   fprintf (stderr, "Could not find rtlsdr_get_tuner_gains\n");
 	   return false;
@@ -475,105 +448,104 @@ bool	rtlsdrHandler::load_rtlFunctions() {
 
 
 	rtlsdr_set_tuner_gain_mode	= (pfnrtlsdr_set_tuner_gain_mode)
-	                     GETPROCADDRESS (Handle, "rtlsdr_set_tuner_gain_mode");
+                         phandle->resolve("rtlsdr_set_tuner_gain_mode");
 	if (rtlsdr_set_tuner_gain_mode == nullptr) {
 	   fprintf (stderr, "Could not find rtlsdr_set_tuner_gain_mode\n");
 	   return false;
 	}
 
 	rtlsdr_set_agc_mode	= (pfnrtlsdr_set_agc_mode)
-	                     GETPROCADDRESS (Handle, "rtlsdr_set_agc_mode");
+                         phandle->resolve("rtlsdr_set_agc_mode");
 	if (rtlsdr_set_agc_mode == nullptr) {
 	   fprintf (stderr, "Could not find rtlsdr_set_agc_mode\n");
 	   return false;
 	}
 
-	rtlsdr_set_tuner_gain	= (pfnrtlsdr_set_tuner_gain)
-	                     GETPROCADDRESS (Handle, "rtlsdr_set_tuner_gain");
+    rtlsdr_set_tuner_gain	= (pfnrtlsdr_set_tuner_gain) phandle->resolve("rtlsdr_set_tuner_gain");
 	if (rtlsdr_set_tuner_gain == nullptr) {
 	   fprintf (stderr, "Cound not find rtlsdr_set_tuner_gain\n");
 	   return false;
 	}
 
 	rtlsdr_get_tuner_gain	= (pfnrtlsdr_get_tuner_gain)
-	                     GETPROCADDRESS (Handle, "rtlsdr_get_tuner_gain");
+                         phandle->resolve("rtlsdr_get_tuner_gain");
 	if (rtlsdr_get_tuner_gain == nullptr) {
 	   fprintf (stderr, "Could not find rtlsdr_get_tuner_gain\n");
 	   return false;
 	}
 
 	rtlsdr_set_center_freq	= (pfnrtlsdr_set_center_freq)
-	                     GETPROCADDRESS (Handle, "rtlsdr_set_center_freq");
+                         phandle->resolve("rtlsdr_set_center_freq");
 	if (rtlsdr_set_center_freq == nullptr) {
 	   fprintf (stderr, "Could not find rtlsdr_set_center_freq\n");
 	   return false;
 	}
 
 	rtlsdr_set_tuner_bandwidth	= (pfnrtlsdr_set_center_freq)
-	                     GETPROCADDRESS (Handle, "rtlsdr_set_tuner_bandwidth");
+	                     phandle->resolve("rtlsdr_set_tuner_bandwidth");
 	if (rtlsdr_set_tuner_bandwidth == nullptr) {
 	   fprintf (stderr, "Could not find rtlsdr_set_tuner_bandwidth\n");
 	   return false;
 	}
 
 	rtlsdr_get_center_freq	= (pfnrtlsdr_get_center_freq)
-	                     GETPROCADDRESS (Handle, "rtlsdr_get_center_freq");
+                         phandle->resolve("rtlsdr_get_center_freq");
 	if (rtlsdr_get_center_freq == nullptr) {
 	   fprintf (stderr, "Could not find rtlsdr_get_center_freq\n");
 	   return false;
 	}
 
 	rtlsdr_reset_buffer	= (pfnrtlsdr_reset_buffer)
-	                     GETPROCADDRESS (Handle, "rtlsdr_reset_buffer");
+                         phandle->resolve("rtlsdr_reset_buffer");
 	if (rtlsdr_reset_buffer == nullptr) {
 	   fprintf (stderr, "Could not find rtlsdr_reset_buffer\n");
 	   return false;
 	}
 
 	rtlsdr_read_async	= (pfnrtlsdr_read_async)
-	                     GETPROCADDRESS (Handle, "rtlsdr_read_async");
+                         phandle->resolve("rtlsdr_read_async");
 	if (rtlsdr_read_async == nullptr) {
 	   fprintf (stderr, "Cound not find rtlsdr_read_async\n");
 	   return false;
 	}
 
 	rtlsdr_get_device_count	= (pfnrtlsdr_get_device_count)
-	                     GETPROCADDRESS (Handle, "rtlsdr_get_device_count");
+                         phandle->resolve("rtlsdr_get_device_count");
 	if (rtlsdr_get_device_count == nullptr) {
 	   fprintf (stderr, "Could not find rtlsdr_get_device_count\n");
 	   return false;
 	}
 
 	rtlsdr_cancel_async	= (pfnrtlsdr_cancel_async)
-	                     GETPROCADDRESS (Handle, "rtlsdr_cancel_async");
+                         phandle->resolve("rtlsdr_cancel_async");
 	if (rtlsdr_cancel_async == nullptr) {
 	   fprintf (stderr, "Could not find rtlsdr_cancel_async\n");
 	   return false;
 	}
 
 	rtlsdr_set_direct_sampling = (pfnrtlsdr_set_direct_sampling)
-	                  GETPROCADDRESS (Handle, "rtlsdr_set_direct_sampling");
+                      phandle->resolve("rtlsdr_set_direct_sampling");
 	if (rtlsdr_set_direct_sampling == nullptr) {
 	   fprintf (stderr, "Could not find rtlsdr_set_direct_sampling\n");
 	   return false;
 	}
 
 	rtlsdr_set_freq_correction = (pfnrtlsdr_set_freq_correction)
-	                  GETPROCADDRESS (Handle, "rtlsdr_set_freq_correction");
+                      phandle->resolve("rtlsdr_set_freq_correction");
 	if (rtlsdr_set_freq_correction == nullptr) {
 	   fprintf (stderr, "Could not find rtlsdr_set_freq_correction\n");
 	   return false;
 	}
 	
 	rtlsdr_get_device_name = (pfnrtlsdr_get_device_name)
-	                  GETPROCADDRESS (Handle, "rtlsdr_get_device_name");
+                      phandle->resolve("rtlsdr_get_device_name");
 	if (rtlsdr_get_device_name == nullptr) {
 	   fprintf (stderr, "Could not find rtlsdr_get_device_name\n");
 	   return false;
 	}
 
 	rtlsdr_set_bias_tee = (pfnrtlsdr_set_bias_tee)
-	                  GETPROCADDRESS (Handle, "rtlsdr_set_bias_tee");
+	             phandle->resolve("rtlsdr_set_bias_tee");
 
 	if (rtlsdr_set_bias_tee == nullptr)
 	   fprintf (stderr, "biasControl will not work\n");

--- a/dab-maxi/qt-devices/rtlsdr-handler/rtlsdr-handler.h
+++ b/dab-maxi/qt-devices/rtlsdr-handler/rtlsdr-handler.h
@@ -39,6 +39,7 @@
 #include	"device-handler.h"
 #include	"ringbuffer.h"
 #include	"ui_rtlsdr-widget.h"
+#include    <QLibrary>
 class	dll_driver;
 class	xml_fileWriter;
 //
@@ -105,7 +106,7 @@ private:
 	QSettings	*rtlsdrSettings;
 	int32_t		inputRate;
 	int32_t		deviceCount;
-	HINSTANCE	Handle;
+    QLibrary*	phandle;
 	dll_driver	*workerHandle;
 	int32_t		lastFrequency;
 	int16_t		gainsCount;

--- a/dab-maxi/radio.cpp
+++ b/dab-maxi/radio.cpp
@@ -623,8 +623,10 @@ uint8_t	dabBand;
 	muting		= false;
 //
 	QPalette lcdPalette;
+#ifndef __MAC__
 	lcdPalette. setColor (QPalette::Background, Qt::white);
 	lcdPalette. setColor (QPalette::Base, Qt::black);
+#endif
 	snrDisplay		-> setPalette (lcdPalette);
 	snrDisplay		-> setAutoFillBackground (true);
 	frequencyDisplay	-> setPalette (lcdPalette);

--- a/includes/backend/mm_malloc.h
+++ b/includes/backend/mm_malloc.h
@@ -39,6 +39,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #if defined(_WIN32) || defined(_WIN64)
 #define MALLOC(a) _mm_malloc(a, 16)
+#elif defined(__APPLE__)
+#include <stdlib.h>
 #else
 #include <malloc.h>
 #define MALLOC(a) memalign(16, a)


### PR DESCRIPTION
Mac support for dabstick and hackrf.
Use Qt version of loading shared libraries (dabstick & hackrf)
Additional changes for mac os (such as malloc), clang changes
fixes for using namespace std in http- (as clang refuse to accept)
Changes to the  *.pro-file, use PKGCONFIG, use Qt standard to load Qwt.
(all dependencies have been installed with homebrew)
(Also works under Ubuntu)