### PR TITLE
Reformatting readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,175 +1,56 @@
 # Qt-DAB-4.4.2 [![Build Status](https://travis-ci.com/JvanKatwijk/qt-dab.svg?branch=master)](https://travis-ci.com/JvanKatwijk/qt-dab)
 
-Qt-DAB-4.  dn Qt-DAB-5 is software for Linux, Windows and Raspberry Pi for listening to terrestrial Digital Audio Broadcasting (DAB and DAB+).
-
----------------------------------------------------------------
-qt-dab-4 and qt-dab-5, same functionality, different GUI
-----------------------------------------------------------------
-
-Next to Qt-DAB-4 a version with a different GUI is built, Qt-DAB-5.
-While the naming suggests Qt-DAB-5 being a successor, the two versions
-share all sources for processing the data, and differ only
-in their appearance.
-
-The basic idea was to limit the number of controls on the main
-widget and shift everything, not needed for simple interaction
-to the configuration widget (which is now called configuration and control)
-
-dabMini, i.e. the small version for just listening to a service,
-is obsolete, the source can be found as subdirectory in the "obsolete"
-directory.
-
-![4.4](/qt-dab-4.png?raw=true)
-![4.5](/qt-dab-5.png?raw=true)
+**Qt-DAB-4** and **Qt-DAB-5** is software for Linux, Windows, MacOS and Raspberry Pi for listening to terrestrial **Digital Audio Broadcasting (DAB and DAB+)**.
 
 
-----------------------------------------------------------------
-
-Thanks to Richard Huber, Qt-DAB can be compiled on the Mac
-
------------------------------------------------------------------
-A note on showing a map
------------------------------------------------------------------
-
-![4.4](/qt-dab-maps.png?raw=true)
-
-Since some time the Qt-DAB versions have a button labeled "http",
-when touched, a small webserver starts that can show the position(s)
-of the transmitter(s) received on the map. 
-
-By default, on starting the server, the "standard" browser on the
-system will be invoked, listening to port 8080.
-The configuration (configuration/control) widget contains a selector
-for switching this off, so that one might choose his/hers own browser.
-
-The feature will not work if
- * handling the TII database is not installed on the system, and/or
- * you did not provide your "home" coordinates.
-
-The latter is easily done by touching the button "coordinates" on the
-configuration (configuration/control) widget.
-
-----------------------------------------------------------------
-Building an executable for qt-dab: a few notes
-----------------------------------------------------------------
-
-While for Linux-x64 and Windows there are precompiled versions, there
-may be reasons to build an executable. Building an executable is not
-very complicated,  it is described in detail in the manual.
-Since it is customary to avoid reading a manual, here are the
-basic steps for the build process.
-
-Step 1:	
-
-	Note that the sources for 4.4.2 are now in the subdirectory qt-dab-s4
-	and for qt-dab-5.0 in the subdirectory qt-dab-s5
-	Install required libraries, see section 5.5.3 (page 29)
-	of the manual for 4.4.
-	Note: It turns out that in recent versions of Debian (and related)		distributions the lib *qt5-default* does not exist as as
-	separate library.
-	It seems to be part of another of the qt5 packages that is installed.
-	Be aware that different distributions store qt files on different
-	locations, adapt the INCLUDEPATH setting in the ".pro" file if needed.
-
-Step 2:
-
-	While there are dozens of configuration options, take note of the
-	following ones:
-
-	for "soapy" software should have
-	been installed, so leave them commented out when not available.
-	Note that "pluto-2" can be compiled in: as the other support programs,
-	when the device is selected, the support program  will (try to)
-	read in the functions of the device library.
-
-	For X64 PC's one may choose the option "CONFIG+=PC" (for selecting SSE
-	instructions). If unsure, use "CONFIG+=NO_SSE".
-
-	For letting the software show the transmitter and the azimuth,
-	choose  "CONFIG += tiiLib" (see step 4).
-
-	Note that the file "converted_map.h" is a generated file that contains
-	a binary version of the HTML/javascript code for the server.
-
-step 3:
-
-	run qmake (variants of the name are qt5-qmake, qmake-qt5)
-	which generates a Makefile and then run "Make". 
-
-step 4:
-
-	Install the file "tiiFile.zip" (after unpacking) in the user's home
-	directory (filename .txdata.tii). The file contains the
-	database data for finding the transmitter's name and location.
-	If Qt-DAB cannot find the file, Qt-DAB will just function without
-	showing the names and withut "maps" option.
-
-	If running on an x64 PC or *bullseye* on the RPI you might consider
-	to install *libtii-lib.so* in "usr/local/lib" from "dab-maxi/library".
-	Note however that that that library needs "curl" to be installed
-	and source code for *libtii-lib.so* is not free.
-	*libtii-lib.so* contains functionality for uploading
-	a new database version (the "load" button on the configuration widget).
-	If Qt-DAB cannot find the library, it will just function without
-	the additional functionality.
-
-Note:
-
-	Building a version on a fresh install of "bullseye" on the RPI gave
-	a version that wouldn't run: The *Qt_PLUGIN_PATH* was not set.
-	Setting it as given below solved - for me - the problem
-
-	Qt_5= /usr/lib/arm-linux-gnueabihf/qt5
-	export QT_PLUGIN_PATH=$Qt_5/plugins
-
-------------------------------------------------------------------
 Table of Contents
-------------------------------------------------------------------
+=================================================================
 
-* [Introduction](#Introduction)
+* [Introduction](#introduction)
 * [Features](#features)
 * [Widgets and scopes](#widgets-and-scopes-for-qt-dab)
 * [Documentation](#documentation)
-* [Installation on Windows](#Installation-on-windows)
-* [Installation on Linux x64](#Installation-on-linux-x64)
-* [Interfacing to another device](#Interfacing-to-another-device)
-* [Using user-specified bands](#Using-user-specified-bands)
+* [Installation on Windows](#installation-on-windows)
+* [Installation on Linux x64](#installation-on-linux-x64)
+* [Interfacing to another SDR device](#interfacing-to-another-sdr-device)
+* [Using user-specified bands](#using-user-specified-bands)
 * [xml-files and support](#xml-files-and-support)
+* [Differences between Qt-DAB 4 and 5](#qt-dab-4-and-qt-dab-5-same-functionality-different-gui)
+* [Showing a map for TII](#a-note-on-showing-a-map)
+* [Notes on building an executable](#building-an-executable-for-qt-dab-a-few-notes)
 * [Copyright](#copyright)
 
-------------------------------------------------------------------
 Introduction
-------------------------------------------------------------------
+=================================================================
 
-**Qt-DAB-XX** is a rich implementation of a DAB decoder for use on Linux and Windows based PC's, including some ARM based boards, such as the Raspberry PI 2 and up. It can be used with a variety of SDR devices, including DABsticks,
-all models of the SDRplay, AIRspy etc.
+**Qt-DAB-XX** is a rich implementation of a DAB decoder for use on Linux and Windows based PCs, including some ARM based boards, such as the Raspberry PI 2 and up. It can be used with a variety of SDR devices, including DABsticks, all models of the SDRplay, Airspy etc.
 
-Precompiled versions for Linux-x64 (AppImage) and Windows (an installer)
-are available. 
-------------------------------------------------------------------
+Precompiled versions for Linux-x64 (AppImage) and Windows (an installer) are available. 
+
+Thanks to Richard Huber, **Qt-DAB** can be compiled on the Mac.
+
 Features
-------------------------------------------------------------------
+=================================================================
 
-  * DAB (mp2) and DAB+ (HE-AAC v1, HE-AAC v2 and LC-AAC) decoding
+  * DAB (mp2) and DAB+ (HE-AAC v1, HE-AAC v2 and AAC-LC) decoding
   * MOT SlideShow (SLS)
   * Dynamic Label (DLS) and the possibility of saving dynamic Labels - augmented with channel and time info - in a file,
   * Both DAB bands (and user defined bands) are supported: 
   	* VHF Band III (default),
    	* L-Band (obsolete now),
 	* a user defined Band
-  * Modes I, II and IV (Mode I default, Modes II and IV obsolete, but can be set in the ".ini" file,
+  * Modes I, II and IV (Mode I default, Modes II and IV obsolete, but can be set in the `.ini` file,
   * Views on the signal: spectrum view incl. constellation diagram, correlation result, TII spectrum and the SNR over time,
   * automatic reconfiguration of services,
   * Detailed information on reception and selected service (SNR, bitrate, frequency, ensemble name, ensemble ID, subchannel ID, used CUs, protection level, CPU usage, program type, language, alternative FM frequency if available, 4 quality bars),
-  * If configured, the TII data is mapped upon a transmitter's name,
-  and  display of TII (Transmitter Identification Information) data when transmitted,
+  * If configured, the TII data is mapped upon a transmitter's name, and display of TII (Transmitter Identification Information) data when transmitted,
   * Possibility of displaying a map with position(s) of received transmitter(s),
   * *Presets* for easy switching of programs in different ensembles (see section *Presets*),
-  * *Dumping* of the input data of the DAB channel (Warning: produces large raw files!) into \* sdr files or xml file formats and playing them again later (see section on xml format),
+  * *Dumping* of the input data of the DAB channel (Warning: produces large raw files!) into `.sdr` files or `.xml` file formats and playing them again later (see section on xml format),
   * Saving audio as uncompressed wave files, and Saving aac frames from DAB+ services for processing by e.g. VLC,
-  * Saving the ensemble content description: audio and data streams, including almost all technical data) into a text file readable by e.g *LibreOfficeCalc*
+  * Saving the ensemble content description: audio and data streams, including almost all technical data into a text file readable by e.g *LibreOfficeCalc*
   * Advanced scanning function (scan the band, show the results on the screen and save a detailed description of the services found in a file),
-  * ip output: when configured the ip data - if selected - is sent to a specificied ip address (default: 127.0.0.1:8888),
+  * ip output: when configured the ip data - if selected - is sent to a specified ip address (default: 127.0.0.1:8888),
   * TPEG output: when configured the data is sent to a specified ip address,
   * EPG detection and building up a time table,
   * Supports as input device:
@@ -180,15 +61,15 @@ Features
 	- limeSDR, 
 	- Adalm Pluto,
 	- Soapy (experimental, Linux only), 
-	- ExtIO (expertimental, Windows only),
+	- ExtIO (experimental, Windows only),
 	- rtl_tcp servers.
   * Always supported input from:
-   	- prerecorded dump (*.raw, *.iq and *.sdr),
-	- xml format files.
+   	- prerecorded dump (`.raw`, `.iq` and `.sdr`),
+	- `.xml` and `.uff` format files.
   * Clean device interface, easy to add other devices.
   * Scheduling the start of (channel:service) pairs or operations as frame dump or audio dump, even for days ahead.
   * Showing the name of the transmitter received as well as the distance to the receiver and the azimuth.
-  * background services. Since 4.351 it is possible to run an arbitray number of DAB+ audioservices (from the current ensemble) as background service with the output sent to a file.
+  * background services. Since 4.351 it is possible to run an arbitrary number of DAB+ audioservices (from the current ensemble) as background service with the output sent to a file.
 
 Partly implemented:
 
@@ -196,24 +77,102 @@ Partly implemented:
   * Journaline (an untested Journaline implementation is part of the sources).
   * Other bands than used for terrestrial broadcasting in Europe (like DAB over cable)
 
-Note:
-While the 2.13 support for SDRplay devices is able to handle
-the RSP 1, RSP II, RSP Ia and RSP duo,
-the 3.0X support handles all SDRplay RSP's.
-It is recommended to use the 3.0X support library.
+:information_source: Note:
+While the 2.13 support for SDRplay devices is able to handle the RSP 1, RSP II, RSP Ia and RSP duo, the 3.0X support handles all SDRplay RSP's. It is recommended to use the 3.0X support library.
 
-------------------------------------------------------------------
+
+qt-dab-4 and qt-dab-5, same functionality, different GUI
+=================================================================
+
+Next to **Qt-DAB-4** a version with a different GUI is built, **Qt-DAB-5**. While the naming suggests Qt-DAB-5 being a successor, the two versions share all sources for processing the data, and differ only in their appearance.
+
+The basic idea was to limit the number of controls on the main widget and shift everything, not needed for simple interaction to the configuration widget (which is now called configuration and control)
+
+**dabMini**, i.e. the small version for just listening to a service, is obsolete, the source can be found as subdirectory in the "obsolete" directory.
+
+![4.4](/qt-dab-4.png?raw=true)
+![4.5](/qt-dab-5.png?raw=true)
+
+
+
+
+A note on showing a map
+=================================================================
+
+![4.4](/qt-dab-maps.png?raw=true)
+
+Since some time the Qt-DAB versions have a button labeled **http**, when touched, a small webserver starts that can show the position(s) of the transmitter(s) received on the map. 
+
+By default, on starting the server, the "standard" browser on the system will be invoked, listening to port 8080. The configuration (configuration/control) widget contains a selector for switching this off, so that one might choose his/hers own browser.
+
+The feature will not work if
+
+ * handling the TII database is not installed on the system, and/or
+ * you did not provide your "home" coordinates.
+
+The latter is easily done by touching the button "coordinates" on the configuration (configuration/control) widget.
+
+
+Building an executable for qt-dab: a few notes
+=================================================================
+
+While for Linux-x64 and Windows there are precompiled versions, there may be reasons to build an executable. Building an executable is not very complicated, it is described in detail in the manual. Since it is customary to avoid reading a manual, here are the basic steps for the build process.
+
+Step 1
+-----------------------------------------------------------------
+
+- :information_source: Note that the sources for 4.4.2 are now in the subdirectory `qt-dab-s4` and for qt-dab-5.0 in the subdirectory `qt-dab-s5` 
+- Install required libraries, see section 5.5.3 (page 29) of the manual for 4.4.
+- :information_source: Note: It turns out that in recent versions of Debian (and related) distributions the lib `qt5-default` does not exist as as separate library.
+- It seems to be part of another of the qt5 packages that is installed.
+- Be aware that different distributions store qt files on different locations, adapt the INCLUDEPATH setting in the `.pro` file if needed.
+
+Step 2
+-----------------------------------------------------------------
+
+While there are dozens of configuration options, take note of the following ones:
+
+For "soapy" software should have been installed, so leave them commented out when not available.
+
+:information_source: Note that "pluto-2" can be compiled in: as the other support programs, when the device is selected, the support program will (try to) read in the functions of the device library.
+
+For X64 PC's one may choose the option `CONFIG+=PC` (for selecting SSE instructions). If unsure, use `CONFIG+=NO_SSE`.
+
+For letting the software show the transmitter and the azimuth, choose `CONFIG += tiiLib` (see step 4).
+
+:information_source: Note that the file `converted_map.h` is a generated file that contains a binary version of the HTML/javascript code for the server.
+
+Step 3
+-----------------------------------------------------------------
+
+run `qmake` (variants of the name are `qt5-qmake`, `qmake-qt5`) which generates a `Makefile` and then run `make`. 
+
+Step 4
+-----------------------------------------------------------------
+
+Unpack `tiiFile.zip` (after unpacking) in the user's home directory (filename .txdata.tii). The file contains the database data for finding the transmitter's name and location. If Qt-DAB cannot find the file, Qt-DAB will just function without showing the names and without "maps" option.
+
+If running on an x64 PC or *bullseye* on the RPI you might consider to install `libtii-lib.so` in `/usr/local/lib` from `dab-maxi/library`.
+
+:information_source: Note however that that that library needs "curl" to be installed and source code for `libtii-lib.so` is not free. `libtii-lib.so` contains functionality for uploading a new database version (the "load" button on the configuration widget). If Qt-DAB cannot find the library, it will just function without the additional functionality.
+
+:information_source: Note:
+
+	Building a version on a fresh install of "bullseye" on the RPI gave a version that wouldn't run: The `Qt_PLUGIN_PATH` was not set. Setting it as given below solved - for me - the problem:
+
+```
+	Qt_5= /usr/lib/arm-linux-gnueabihf/qt5
+	export QT_PLUGIN_PATH=$Qt_5/plugins
+```
+
 Widgets and scopes for Qt-DAB
-------------------------------------------------------------------
+=================================================================
 
-Qt-DAB always shows a main widget; a number of  **optional**
-widgets is visible under user control.
+Qt-DAB always shows a main widget; a number of  **optional** widgets is visible under user control.
 
-Controls, in V4 on the main widget, were in V5 moved to the
-configuration and control widget.
+Controls, in V4 on the main widget, were in V5 moved to the configuration and control widget.
 
-Some data on the selected service - if any - can be found on
-a separate widget, the "Technical Data" widget (*Detail* button).
+Some data on the selected service - if any - can be found on a separate widget, the "Technical Data" widget (*Detail* button).
 
 ![Qt-DAB main widget](/qt-dab-technical-widget.png?raw=true)
 
@@ -230,90 +189,62 @@ Other widgets are
 
 ![Qt-DAB totaal](/qt-dab-scan.png?raw=true)
 
-Another  widget shows when running a *scan*; the widget 
-shows the contents of the ensembles found in the selected channels.
-Since 3.5 the
-possibility exists to save a detailed description of the services
-in the different channels, in a format easy to process with LibreOffice
-or comparable programs (a csv file).
+Another widget shows when running a *scan*; the widget shows the contents of the ensembles found in the selected channels. Since 3.5 the possibility exists to save a detailed description of the services in the different channels, in a format easy to process with LibreOffice or comparable programs (a `.csv` file).
 
-Depending on a setting in configuration widget, a logo or slide, transmitted
-as Program Associated Data with the audio transmission, will be shown here or on a separate widget.
+Depending on a setting in configuration widget, a logo or slide, transmitted as Program Associated Data with the audio transmission, will be shown here or on a separate widget.
 
---------------------------------------------------------------------
 Documentation
---------------------------------------------------------------------
+=================================================================
 
-An extensive "user's guide" - in pdf format - for the 4.4 version
-can be found in the "docs" section of the source tree.
-The documentation contains a complete
-description of the widgets, of the values in the ".ini" file,
-on configuring for creating an executable (Linux), and even a
-complete description on how to add a device to the configuration.
+An extensive **user's guide** - in PDF format - for the 4.4 version can be found in the "docs" section of the source tree. The documentation contains a complete description of the widgets, of the values in the `.ini` file, on configuring for creating an executable (Linux), and even a complete description on how to add a device to the configuration.
 
 ![Qt-DAB documentation](/qt-dab-manual.png?raw=true)
 
-------------------------------------------------------------------
+
 Installation on Windows
---------------------------------------------------------------------
+=================================================================
 
-For windows an  **installer** can be found in the releases section, https://github.com/JvanKatwijk/qt-dab/releases. The installer will install the executable as well as required libraries.
+For Windows an  **installer** can be found in the releases section, https://github.com/JvanKatwijk/qt-dab/releases. The installer will install the executable as well as required libraries.
 
-The installer will also call the official installer for the dll implementing
-the 2.3 api for getting access to the SDRplay devices.
+The installer will also call the official installer for the dll implementing the 2.3 api for getting access to the SDRplay devices.
 
-------------------------------------------------------------------
+
 Installation on Linux-x64
-------------------------------------------------------------------
+=================================================================
 
-For Linux-x64 systems, an **appImage** can be found in the releases section,
-http::github.com/JvanKatwijk/qt-dab/releases. The appImage contains
+For Linux-x64 systems, an **appImage** can be found in the releases section, http://github.com/JvanKatwijk/qt-dab/releases. The appImage contains
 next to the executable qt-dab program, the required libraries.
 
-Of course it is possible to generate an executable,  the manual
-contains a complete script for Ubuntu type Linux versions.
+Of course it is possible to generate an executable, the manual contains a complete script for Ubuntu type Linux versions.
 
------------------------------------------------------------------------
+
 Interfacing to another SDR device
------------------------------------------------------------------------
+=================================================================
 
-There exist - obviously - other devices than the ones supported
-here. Interfacing another device is not very complicated,
-it might be done using the "Soapy" interface, or one might
-write a new interface class.
+There exist - obviously - other devices than the ones supported here. Interfacing another device is not very complicated, it might be done using the **Soapy** interface, or one might write a new interface class.
 
-A complete description of how to interface a device to Qt-DAB
-is given in the user's manual.
+A complete description of how to interface a device to Qt-DAB is given in the user's manual.
 
-------------------------------------------------------------------------
+
 Using user specified bands
-------------------------------------------------------------------------
+=================================================================
 
-While it is known that the DAB transmissions are now all in Band III,
-there are situations where it might is desirable to use other frequencies.
-Specify in a file a list of channels, e.g.
+While it is known that the DAB transmissions are now all in Band III, there are situations where it might is desirable to use other frequencies. Specify in a file a list of channels, e.g.
 
 	jan	227360
 	twee	220352
 	drie	1294000
 	vier	252650
 
-and pass the file on with the "-A" command line switch.
-The channel name is just any identifier, the channel frequency is
-given in KHz. Your SDR device obviously has to support the frequencies
-for these channels.
+and pass the file on with the `-A` command line switch. The channel name is just any identifier, the channel frequency is given in kHz. Your SDR device obviously has to support the frequencies for these channels.
 
--------------------------------------------------------------------------
+
 xml-files and support
--------------------------------------------------------------------------
+=================================================================
 
-Clemens Schmidt, author of the QiRX program and me defined a format
-for storing and exchanging "raw" data: xml-files.
-Such a file contains in the first bytes - up to 5000 - a description
-in xml - as source - of the data contents. This xml description
-describes in detail  the coding of the elements.
-As an example, a description of data obtained by dumping AIRspy
-input. 
+**Clemens Schmidt**, author of the QiRX program (https://qirx.softsyst.com/) and me defined a format for storing and exchanging "raw" data: `.xml`-files. Such a file contains in the first bytes - up to 5000 - a description in xml - as source - of the data contents. This xml description describes in detail the coding of the elements. 
+
+As an example, a description of data obtained by dumping Airspy input: 
 
  ```
 	<?xml version="1.0" encoding="utf-8"?>
@@ -340,22 +271,17 @@ input.
 
  ```
 
-The device handlers in Qt-DAB support the generation of 
-such an xml file.
+The device handlers in Qt-DAB support the generation of such an `.xml` file.
 
-While the current implementation for reading such files is limited to
-a single data block, the reader contains a *cont* button that, when
-touched while playing the data, will cause continuous playing of the
-data in the data block.
+While the current implementation for reading such files is limited to a single data block, the reader contains a *cont* button that, when touched while playing the data, will cause continuous playing of the data in the data block.
 
 ![Qt-DAB with xml input](/qt-dab-xml.png?raw=true)
 
-The picture shows the reader when reading a file, generated from raw
-data emitted by the Hackrf device.
+The picture shows the reader when reading a file, generated from raw data emitted by the HackRF device.
 
------------------------------------------------------------------------
+
 Copyright
-------------------------------------------------------------------------
+=================================================================
 
 	Copyright (C)  2016 .. 2022
 	Jan van Katwijk (J.vanKatwijk@gmail.com)

--- a/README.md
+++ b/README.md
@@ -150,15 +150,13 @@ run `qmake` (variants of the name are `qt5-qmake`, `qmake-qt5`) which generates 
 Step 4
 -----------------------------------------------------------------
 
-Unpack `tiiFile.zip` (after unpacking) in the user's home directory (filename .txdata.tii). The file contains the database data for finding the transmitter's name and location. If Qt-DAB cannot find the file, Qt-DAB will just function without showing the names and without "maps" option.
+Unpack file `.txdata.tii` (which contains the database data for finding the transmitter's name and location) from `tiiFile.zip` into the user's home directory. If Qt-DAB cannot find the file, it will just function without showing the names and without "maps" option.
 
 If running on an x64 PC or *bullseye* on the RPI you might consider to install `libtii-lib.so` in `/usr/local/lib` from `dab-maxi/library`.
 
-:information_source: Note however that that that library needs "curl" to be installed and source code for `libtii-lib.so` is not free. `libtii-lib.so` contains functionality for uploading a new database version (the "load" button on the configuration widget). If Qt-DAB cannot find the library, it will just function without the additional functionality.
+:information_source: Note however that this library needs `curl` to be installed and source code for `libtii-lib.so` is not free. `libtii-lib.so` contains functionality for uploading a new database version (the "load" button on the configuration widget). If Qt-DAB cannot find the library, it will just function without the additional functionality.
 
-:information_source: Note:
-
-	Building a version on a fresh install of "bullseye" on the RPI gave a version that wouldn't run: The `Qt_PLUGIN_PATH` was not set. Setting it as given below solved - for me - the problem:
+:information_source: Note: Building a version on a fresh install of "bullseye" on the RPI gave a version that wouldn't run: The `Qt_PLUGIN_PATH` was not set. Setting it as given below solved - for me - the problem:
 
 ```
 	Qt_5= /usr/lib/arm-linux-gnueabihf/qt5
@@ -168,7 +166,7 @@ If running on an x64 PC or *bullseye* on the RPI you might consider to install `
 Widgets and scopes for Qt-DAB
 =================================================================
 
-Qt-DAB always shows a main widget; a number of  **optional** widgets is visible under user control.
+Qt-DAB always shows a main widget; a number of **optional** widgets is visible under user control.
 
 Controls, in V4 on the main widget, were in V5 moved to the configuration and control widget.
 


### PR DESCRIPTION
- reformatting, removing double spaces and unnecessary line wraps
- files are quoted with `accent`
- fixed headlines (no -- before in markdown) and using = for headline 1 and - for headline 2
- fixed some typos (KHz)
- added `uff` file extension
- AAC-LC instead of LC-AAC
- wrong link to releases
- added link to https://qirx.softsyst.com/
- fixed all anchors
- added :information_source: icon
- moved TOC and introduction up