### PR TITLE
xml time in number format and use kHz

### DIFF
--- a/qt-devices/xml-filewriter.cpp
+++ b/qt-devices/xml-filewriter.cpp
@@ -141,7 +141,7 @@ QDomElement root	= theTree. createElement ("SDR");
 	char help [256];
 	strcpy (help, asctime (timeinfo));
 	help [strlen (help)] = 0;	// get rid of \n
-	theTime. setAttribute ("Value", asctime (timeinfo));
+	theTime. setAttribute ("Value", QDateTime::currentDateTimeUtc().toString("yyyy-MM-dd hh:mm:ss"));
 	root. appendChild (theTime);
 	QDomElement theSample = theTree. createElement ("Sample");
 	QDomElement theRate   = theTree. createElement ("Samplerate");
@@ -169,7 +169,7 @@ QDomElement root	= theTree. createElement ("SDR");
 	QDomElement theFrequency	= theTree. createElement ("Frequency");	
 	theFrequency. setAttribute ("Value", 
 	                                 QString::number (frequency / 1000));
-	theFrequency. setAttribute ("Unit", "KHz");
+	theFrequency. setAttribute ("Unit", "kHz");
 	theDataBlock. appendChild (theFrequency);
 	QDomElement theModulation	= theTree. createElement ("Modulation");
 	theModulation. setAttribute ("Value", "DAB");


### PR DESCRIPTION
- instead of local 
`<Time Unit="UTC" Value="Mon Feb  6 23:27:02 2023&#xa;"/>` 
the xml now displays the time in UTC
`<Time Value="2023-02-06 22:45:09" Unit="UTC"/>`
- meaning there was an offset of 1 resp. 2 hour(s) in Central Europe 
- the line feed is now obsolete
- the word KHz is replaced by kHz according to a comment in https://www.rundfunkforum.de/viewtopic.php?p=1698797#p1698797

![grafik](https://user-images.githubusercontent.com/24510556/217105816-e2fe621e-aadb-4708-b1d3-5f8dc6924cf6.png)
