### PR TITLE
DAB frequency with 7 digits

### DIFF
--- a/qt-dab-s5/forms-v5/config-helper.ui
+++ b/qt-dab-s5/forms-v5/config-helper.ui
@@ -51,6 +51,9 @@
              <property name="toolTip">
               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Current frequency (in MHz)&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
              </property>
+             <property name="digitCount">
+              <number>7</number>
+             </property>
              <property name="segmentStyle">
               <enum>QLCDNumber::Flat</enum>
              </property>


### PR DESCRIPTION
it is common to have the DAB frequency in format xxx.xxx MHz, so I've changed the field in `config-helper.ui` to 7 digits

Feel free to enlarge the field as it got smaller ...

![grafik](https://user-images.githubusercontent.com/24510556/217108833-26c5c7c9-dd89-48c0-837e-ea330b2eab3d.png)
