### PR TITLE
Fix two recent HackRF regressions

### DIFF
--- a/qt-devices/hackrf-handler/hackrf-handler.cpp
+++ b/qt-devices/hackrf-handler/hackrf-handler.cpp
@@ -174,7 +174,7 @@
 	connect (this, &hackrfHandler::signal_antEnable,
 	         biasT_button, &QCheckBox::setChecked);
 	connect (this, &hackrfHandler::signal_ampEnable,
-	         biasT_button, &QCheckBox::setChecked);
+	         AmpEnableButton, &QCheckBox::setChecked);
 	connect (this, &hackrfHandler::signal_vgaValue,
 		 vgaGainSlider, &QSlider::setValue);
 	connect (this, &hackrfHandler::signal_vgaValue,

--- a/qt-devices/hackrf-handler/hackrf-handler.cpp
+++ b/qt-devices/hackrf-handler/hackrf-handler.cpp
@@ -365,7 +365,7 @@ int	res;
 //	The brave old getSamples. For the hackrf, we get
 //	size still in I/Q pairs
 int32_t	hackrfHandler::getSamples (std::complex<float> *V, int32_t size) { 
-auto *temp = dynVec (std::complex<int16_t>, size);
+auto *temp = dynVec (std::complex<int8_t>, size);
 	int amount      = _I_Buffer. getDataFromBuffer (temp, size);
 	for (int i = 0; i < amount; i ++)
 	   V [i] = std::complex<float> (real (temp [i]) / 127.0f,


### PR DESCRIPTION
I noticed two recent regressions in the HackRF backend:

1. No reception with the HackRF at all. Reason was an inadvertent change in the sample data type.
2. The biasT checkbox was automatically checked whenever the RF amplifier was enabled. Reason was a mistake in the wiring of the Qt checkbox.

Both are fixed by these commits. See the commit messages for further details.