### PR TITLE
cmake: Improve FindQwt

### DIFF
--- a/cmake/Modules/FindQwt.cmake
+++ b/cmake/Modules/FindQwt.cmake
@@ -16,6 +16,7 @@ find_path(QWT_INCLUDE_DIRS
 	/usr/include/qwt6
 	/usr/include/qwt6-qt6
 	/usr/include/qt6/qwt
+	/usr/include/qt6/qwt6
 	/opt/local/include/qwt
 	/sw/include/qwt
 	/usr/local/lib/qwt.framework/Headers
@@ -49,13 +50,13 @@ if(QWT_INCLUDE_DIRS)
   set(QWT_VERSION "No Version")
   string(REGEX MATCH "[0-9]+.[0-9]+.[0-9]+" QWT_VERSION ${QWT_STRING_VERSION})
   string(COMPARE LESS ${QWT_VERSION} "5.2.0" QWT_WRONG_VERSION)
-  string(COMPARE GREATER ${QWT_VERSION} "6.2.0" QWT_WRONG_VERSION)
+  string(COMPARE GREATER ${QWT_VERSION} "6.3.0" QWT_WRONG_VERSION)
 
   message(STATUS "QWT Version: ${QWT_VERSION}")
   if(NOT QWT_WRONG_VERSION)
     set(QWT_FOUND TRUE)
   else(NOT QWT_WRONG_VERSION)
-    message(STATUS "QWT Version must be >= 5.2 and <= 6.2.0, Found ${QWT_VERSION}")
+    message(STATUS "QWT Version must be >= 5.2 and <= 6.3.0, Found ${QWT_VERSION}")
   endif(NOT QWT_WRONG_VERSION)
 
 endif(QWT_INCLUDE_DIRS)


### PR DESCRIPTION
* Add /usr/include/qt6/qwt6 to find qwt on openSUSE systems
* Allow QWT versions up to 6.3.0 to be used