### PR TITLE
Fix load selection signal connection

### DIFF
--- a/sources/main/config-handler.cpp
+++ b/sources/main/config-handler.cpp
@@ -236,7 +236,7 @@ int	index_for_key (int key) {
 #if QT_VERSION >= QT_VERSION_CHECK(6, 7, 0)
 	connect (loadSelection_selector, &QCheckBox::checkStateChanged,
 #else
-	connect (kiadSelection_selector, &QCheckBox::stateChanged,
+	connect (loadSelection_selector, &QCheckBox::stateChanged,
 #endif
 	         this, &configHandler::handle_loadSelection_selector);
 #if QT_VERSION >= QT_VERSION_CHECK(6, 7, 0)


### PR DESCRIPTION
## Summary
- fix the Qt 5 signal connection for `loadSelection_selector`
- replace the misspelled `kiadSelection_selector` identifier with the existing UI member

## Validation
- `rg -n "kiadSelection_selector" .` returns no matches after the change
- `rg -n "loadSelection_selector|handle_loadSelection_selector|LOAD_SELECTION" sources/main/config-handler.cpp sources/main/config-handler.h sources/main/forms-v7/config-helper.ui` confirms the connected checkbox, handler, and stored setting use `loadSelection` consistently
- `git diff --check`

I did not run a full Qt build locally because this environment does not have `qmake`, `qmake6`, or `cmake`, and the checkout has no generated Makefile for `make -n`. The change is limited to the identifier reported in #398.